### PR TITLE
[codex] Prepare v2.5.0 release docs

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,8 +9,18 @@
 
 ## [Unreleased]
 
-### 初期リリース
+## [2.5.0] - 2026-04-26
+
+### 追加
 
 - [scottlz0310/Mcp-Docker](https://github.com/scottlz0310/Mcp-Docker) の `services/copilot-review-mcp/` を独立リポジトリへ分離
-- ghcr.io への Docker イメージ公開 CI を追加
-- Mcp-Docker までの履歴は移行していない。関連する設計・経緯は `docs/` 配下を参照
+- Copilot review workflow 向けの OAuth 対応 Streamable HTTP MCP サーバーを追加
+- async watch ツール、review thread の reply/resolve ツール、`pr-review-cycle` skill テンプレートを追加
+- SQLite による watch state 永続化と、プロセス再起動後の stale watch 検知を追加
+- README、changelog、watch tool docs、skill docs、usage docs を英日バイリンガル化
+- test、scan、build、ghcr.io への Docker image 公開 CI を追加
+
+### 補足
+
+- この独立リポジトリでは、Mcp-Docker 時代の `copilot-review-mcp` service 作業から release continuity を引き継ぐ。git 履歴は移行していない。
+- 関連する設計・移行経緯は `docs/` 配下を参照。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Initial Release
+## [2.5.0] - 2026-04-26
+
+### Added
 
 - Split `services/copilot-review-mcp/` from [scottlz0310/Mcp-Docker](https://github.com/scottlz0310/Mcp-Docker) into a standalone repository
-- Added CI to publish Docker images to ghcr.io
-- Git history was not migrated; see `docs/` for related design context and history
+- Added the OAuth-enabled Streamable HTTP MCP server for Copilot review workflows
+- Added async watch tools, review-thread reply/resolve tools, and the `pr-review-cycle` skill template
+- Added SQLite-persisted watch state with stale-watch detection after process restart
+- Added bilingual English/Japanese README, changelog, watch-tool docs, skill docs, and usage docs
+- Added CI to test, scan, build, and publish Docker images to ghcr.io
+
+### Notes
+
+- This standalone repository preserves release continuity from the original `copilot-review-mcp` service work in Mcp-Docker; git history was not migrated.
+- See `docs/` for related design context and migration history.

--- a/README.ja.md
+++ b/README.ja.md
@@ -32,7 +32,7 @@ OAuth ファサードを内蔵しており、Streamable HTTP transport で `clau
 | `reply_and_resolve_review_thread` | 返信→解決を順次実行 |
 | `wait_for_copilot_review` | legacy blocking wait（fallback） |
 
-詳細は [docs/watch-tools.ja.md](docs/watch-tools.ja.md) と [docs/skills/pr-review-cycle.ja.md](docs/skills/pr-review-cycle.ja.md) を参照。
+セットアップと運用は [docs/usage.ja.md](docs/usage.ja.md) を参照。ツール単位の詳細は [docs/watch-tools.ja.md](docs/watch-tools.ja.md) と [docs/skills/pr-review-cycle.ja.md](docs/skills/pr-review-cycle.ja.md) を参照。
 
 ## クイックスタート（Docker）
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Built-in OAuth facade enables direct connections from MCP clients such as `claud
 | `reply_and_resolve_review_thread` | Reply then resolve in sequence |
 | `wait_for_copilot_review` | Legacy blocking wait (fallback) |
 
-See [docs/watch-tools.md](docs/watch-tools.md) and [docs/skills/pr-review-cycle.md](docs/skills/pr-review-cycle.md) for details.
+See [docs/usage.md](docs/usage.md) for setup and operation. Tool-level details are in [docs/watch-tools.md](docs/watch-tools.md) and [docs/skills/pr-review-cycle.md](docs/skills/pr-review-cycle.md).
 
 ## Quick Start (Docker)
 

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -1,0 +1,292 @@
+# 使い方
+
+[English](usage.md)
+
+このドキュメントでは、`copilot-review-mcp` を MCP サーバーとして動かすための基本設定をまとめる。
+
+- GitHub OAuth App の設定
+- Docker コンテナのビルド、起動、終了、ログ確認
+- MCP クライアント側の基本設定例
+- `pr-review-cycle` skill の配置方法
+
+ツール単位の流れは [watch-tools.ja.md](watch-tools.ja.md)、skill テンプレート本体は [skills/pr-review-cycle.ja.md](skills/pr-review-cycle.ja.md) を参照。
+
+## 1. GitHub OAuth App を作成する
+
+利用する公開 URL ごとに OAuth App を 1 つ作る。
+
+ローカル Docker で使う場合:
+
+| 項目 | 値 |
+|---|---|
+| Application name | `copilot-review-mcp local` |
+| Homepage URL | `http://localhost:8083` |
+| Authorization callback URL | `http://localhost:8083/callback` |
+
+外部ホストで使う場合:
+
+| 項目 | 値 |
+|---|---|
+| Application name | `copilot-review-mcp` |
+| Homepage URL | `https://<your-host>` |
+| Authorization callback URL | `https://<your-host>/callback` |
+
+作成後に行うこと:
+
+1. Client ID を `GITHUB_CLIENT_ID` に設定する。
+2. Client Secret を生成し、`GITHUB_CLIENT_SECRET` に設定する。
+3. secret は Git に入れない。
+
+GitHub OAuth App の設定画面:
+
+- 個人アカウント: <https://github.com/settings/developers>
+- Organization: `https://github.com/organizations/<org>/settings/applications`
+
+参考: [GitHub Docs: Creating an OAuth app](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app)
+
+## 2. 環境変数を準備する
+
+`.env.template` から `.env` を作成し、OAuth App の値を入れる。
+
+```bash
+cp .env.template .env
+```
+
+PowerShell:
+
+```powershell
+Copy-Item .env.template .env
+```
+
+ローカルでの最小設定:
+
+```env
+GITHUB_CLIENT_ID=your_client_id
+GITHUB_CLIENT_SECRET=your_client_secret
+BASE_URL=http://localhost:8083
+GITHUB_OAUTH_SCOPES=repo,user
+MCP_PORT=8083
+SQLITE_PATH=/data/copilot-review.db
+```
+
+注意:
+
+- `BASE_URL` は OAuth App の callback URL の host と一致させる。
+- GitHub OAuth App の callback URL は `$BASE_URL/callback` にする。
+- 現在の redirect host allowlist の既定値は `localhost`, `127.0.0.1`, `vscode.dev`。
+- hosted `claude.ai` 運用には [#6](https://github.com/scottlz0310/copilot-review-mcp/issues/6) で扱う redirect host allowlist の設定対応が必要。
+
+## 3. Docker で起動する
+
+### 公開済みイメージを pull
+
+```bash
+docker pull ghcr.io/scottlz0310/copilot-review-mcp:latest
+```
+
+### ローカルで build
+
+```bash
+docker build -t copilot-review-mcp:dev .
+```
+
+### コンテナを起動
+
+公開済みイメージ:
+
+```bash
+docker run -d --name copilot-review-mcp \
+  --env-file .env \
+  -p 127.0.0.1:8083:8083 \
+  -v copilot-review-data:/data \
+  ghcr.io/scottlz0310/copilot-review-mcp:latest
+```
+
+ローカル build イメージ:
+
+```bash
+docker run -d --name copilot-review-mcp \
+  --env-file .env \
+  -p 127.0.0.1:8083:8083 \
+  -v copilot-review-data:/data \
+  copilot-review-mcp:dev
+```
+
+PowerShell では 1 行で実行すると確実。
+
+```powershell
+docker run -d --name copilot-review-mcp --env-file .env -p 127.0.0.1:8083:8083 -v copilot-review-data:/data ghcr.io/scottlz0310/copilot-review-mcp:latest
+```
+
+### health check
+
+```bash
+curl http://127.0.0.1:8083/health
+```
+
+PowerShell:
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8083/health
+```
+
+期待するレスポンス:
+
+```json
+{"status":"ok"}
+```
+
+### ログ確認
+
+```bash
+docker logs -f copilot-review-mcp
+```
+
+### 停止、再起動、削除
+
+```bash
+docker stop copilot-review-mcp
+docker start copilot-review-mcp
+docker rm -f copilot-review-mcp
+```
+
+named volume には SQLite の watch state DB が残る。
+
+```bash
+docker volume ls --filter name=copilot-review-data
+```
+
+ローカル状態を削除したい場合だけ volume を削除する。
+
+```bash
+docker volume rm copilot-review-data
+```
+
+## 4. MCP クライアントを設定する
+
+MCP endpoint は以下。
+
+```text
+http://localhost:8083/mcp
+```
+
+Streamable HTTP と OAuth に対応した MCP クライアントにこの URL を登録する。設定ファイルの形はクライアントごとに異なるが、基本値は以下。
+
+```json
+{
+  "mcpServers": {
+    "copilot-review-mcp": {
+      "type": "http",
+      "url": "http://localhost:8083/mcp"
+    }
+  }
+}
+```
+
+クライアントによっては `mcpServers` ではなく `servers`、または `http` ではなく `streamable-http` を使う。URL は同じまま、利用中のクライアントの設定名に合わせる。
+
+VS Code 系の MCP config では、おおむね次の形になる。
+
+```json
+{
+  "servers": {
+    "copilot-review-mcp": {
+      "type": "http",
+      "url": "http://localhost:8083/mcp"
+    }
+  }
+}
+```
+
+初回接続時に OAuth 認可フローが開く。GitHub にログインし、作成した OAuth App を認可する。
+
+## 5. `pr-review-cycle` skill を配置する
+
+このリポジトリには skill テンプレートが入っているが、使う前に AI エージェント側のローカル skill ディレクトリへコピーする。
+
+### Codex
+
+PowerShell:
+
+```powershell
+$skillDir = "$env:USERPROFILE\.codex\skills\pr-review-cycle"
+New-Item -ItemType Directory -Force $skillDir
+Copy-Item docs\skills\pr-review-cycle.ja.md "$skillDir\SKILL.md"
+```
+
+POSIX shell:
+
+```bash
+mkdir -p ~/.codex/skills/pr-review-cycle
+cp docs/skills/pr-review-cycle.ja.md ~/.codex/skills/pr-review-cycle/SKILL.md
+```
+
+### Claude 系の skill ディレクトリ
+
+```bash
+mkdir -p ~/.claude/skills/pr-review-cycle
+cp docs/skills/pr-review-cycle.ja.md ~/.claude/skills/pr-review-cycle/SKILL.md
+```
+
+英語版を使う場合:
+
+```bash
+cp docs/skills/pr-review-cycle.md ~/.codex/skills/pr-review-cycle/SKILL.md
+```
+
+コピー後、利用中のクライアントで tool prefix が異なる場合は skill 内のプレースホルダーを修正する。
+
+| プレースホルダー | 意味 |
+|---|---|
+| `{CRM}` | `copilot-review-mcp` のツール |
+| `{GH}` | コメント、CI、PR 操作に使う GitHub MCP ツール |
+
+## 6. 基本的な review cycle の使い方
+
+前提:
+
+- `copilot-review-mcp` が起動し、MCP クライアントから接続できる。
+- GitHub MCP サーバーまたは GitHub connector も利用できる。
+- 対象リポジトリに open PR がある。
+
+AI エージェントへの典型的な指示:
+
+```text
+$pr-review-cycle
+```
+
+skill は以下を行う。
+
+1. Copilot review の状態確認または依頼
+2. async watch による完了待機
+3. review thread の取得
+4. コメント分類
+5. accepted な修正の実装
+6. remote side effect が許可されている場合の返信・resolve
+7. CI と coverage の確認
+
+マージは、ユーザーが明示的に許可した場合だけ別途行う。
+
+## トラブルシュート
+
+### `redirect_uri host not permitted`
+
+MCP クライアントが送った redirect URI の host がサーバー側で許可されていない。ローカル利用では `localhost`, `127.0.0.1`, `vscode.dev` を使う。Claude Web の hosted 運用には #6 の redirect host 設定対応が必要。
+
+### `invalid_token`
+
+MCP クライアント側で OAuth フローをやり直す。GitHub 側で token を revoke した場合も再認証が必要。
+
+### `session_user_mismatch`
+
+同じ MCP session ID が別の GitHub login で使われた。MCP クライアント側の session cache を削除するか、再接続する。
+
+### コンテナは起動したが `/health` が失敗する
+
+ログを確認する。
+
+```bash
+docker logs copilot-review-mcp
+```
+
+よくある原因は `GITHUB_CLIENT_ID` 未設定、`GITHUB_CLIENT_SECRET` 未設定、または port の競合。

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,292 @@
+# Usage
+
+[日本語](usage.ja.md)
+
+This guide covers the basic setup needed to run `copilot-review-mcp` as an MCP server:
+
+- GitHub OAuth App setup
+- Docker build, start, stop, and logs
+- Basic MCP client configuration
+- `pr-review-cycle` skill installation
+
+For the tool-level flow, see [watch-tools.md](watch-tools.md). For the skill template itself, see [skills/pr-review-cycle.md](skills/pr-review-cycle.md).
+
+## 1. Create a GitHub OAuth App
+
+Create one OAuth App for each public server URL you use.
+
+For local Docker usage:
+
+| Field | Value |
+|---|---|
+| Application name | `copilot-review-mcp local` |
+| Homepage URL | `http://localhost:8083` |
+| Authorization callback URL | `http://localhost:8083/callback` |
+
+For hosted usage:
+
+| Field | Value |
+|---|---|
+| Application name | `copilot-review-mcp` |
+| Homepage URL | `https://<your-host>` |
+| Authorization callback URL | `https://<your-host>/callback` |
+
+After creating the app:
+
+1. Copy the Client ID into `GITHUB_CLIENT_ID`.
+2. Generate a Client Secret and copy it into `GITHUB_CLIENT_SECRET`.
+3. Keep the secret out of Git.
+
+GitHub OAuth App settings are managed from:
+
+- Personal account: <https://github.com/settings/developers>
+- Organization: `https://github.com/organizations/<org>/settings/applications`
+
+Reference: [GitHub Docs: Creating an OAuth app](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app)
+
+## 2. Prepare environment variables
+
+Create `.env` from `.env.template` and fill in the OAuth App values.
+
+```bash
+cp .env.template .env
+```
+
+PowerShell:
+
+```powershell
+Copy-Item .env.template .env
+```
+
+Minimum local configuration:
+
+```env
+GITHUB_CLIENT_ID=your_client_id
+GITHUB_CLIENT_SECRET=your_client_secret
+BASE_URL=http://localhost:8083
+GITHUB_OAUTH_SCOPES=repo,user
+MCP_PORT=8083
+SQLITE_PATH=/data/copilot-review.db
+```
+
+Notes:
+
+- `BASE_URL` must match the OAuth App callback host.
+- The GitHub OAuth App callback URL must be `$BASE_URL/callback`.
+- The default redirect host allowlist is currently `localhost`, `127.0.0.1`, and `vscode.dev`.
+- Hosted `claude.ai` operation needs the redirect host allowlist work tracked in [#6](https://github.com/scottlz0310/copilot-review-mcp/issues/6).
+
+## 3. Run with Docker
+
+### Pull the published image
+
+```bash
+docker pull ghcr.io/scottlz0310/copilot-review-mcp:latest
+```
+
+### Build locally
+
+```bash
+docker build -t copilot-review-mcp:dev .
+```
+
+### Start the container
+
+Published image:
+
+```bash
+docker run -d --name copilot-review-mcp \
+  --env-file .env \
+  -p 127.0.0.1:8083:8083 \
+  -v copilot-review-data:/data \
+  ghcr.io/scottlz0310/copilot-review-mcp:latest
+```
+
+Local image:
+
+```bash
+docker run -d --name copilot-review-mcp \
+  --env-file .env \
+  -p 127.0.0.1:8083:8083 \
+  -v copilot-review-data:/data \
+  copilot-review-mcp:dev
+```
+
+PowerShell can use the same command on one line:
+
+```powershell
+docker run -d --name copilot-review-mcp --env-file .env -p 127.0.0.1:8083:8083 -v copilot-review-data:/data ghcr.io/scottlz0310/copilot-review-mcp:latest
+```
+
+### Check health
+
+```bash
+curl http://127.0.0.1:8083/health
+```
+
+PowerShell:
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8083/health
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+### View logs
+
+```bash
+docker logs -f copilot-review-mcp
+```
+
+### Stop, start again, and remove
+
+```bash
+docker stop copilot-review-mcp
+docker start copilot-review-mcp
+docker rm -f copilot-review-mcp
+```
+
+The named volume keeps the SQLite watch-state database:
+
+```bash
+docker volume ls --filter name=copilot-review-data
+```
+
+Remove it only when you intentionally want to delete local state:
+
+```bash
+docker volume rm copilot-review-data
+```
+
+## 4. Configure an MCP client
+
+The MCP endpoint is:
+
+```text
+http://localhost:8083/mcp
+```
+
+Use an MCP client that supports Streamable HTTP and OAuth. The exact config shape differs by client, but the core values are:
+
+```json
+{
+  "mcpServers": {
+    "copilot-review-mcp": {
+      "type": "http",
+      "url": "http://localhost:8083/mcp"
+    }
+  }
+}
+```
+
+Some clients use `servers` instead of `mcpServers`, or `streamable-http` instead of `http`. Keep the URL unchanged and adapt the field names to your client.
+
+For VS Code-style MCP config, the shape is typically:
+
+```json
+{
+  "servers": {
+    "copilot-review-mcp": {
+      "type": "http",
+      "url": "http://localhost:8083/mcp"
+    }
+  }
+}
+```
+
+When the client first connects, it should open the OAuth authorization flow. Sign in with GitHub and authorize the OAuth App.
+
+## 5. Install the `pr-review-cycle` skill
+
+The repository contains skill templates, but they must be copied into your AI agent's local skill directory before use.
+
+### Codex
+
+PowerShell:
+
+```powershell
+$skillDir = "$env:USERPROFILE\.codex\skills\pr-review-cycle"
+New-Item -ItemType Directory -Force $skillDir
+Copy-Item docs\skills\pr-review-cycle.md "$skillDir\SKILL.md"
+```
+
+POSIX shell:
+
+```bash
+mkdir -p ~/.codex/skills/pr-review-cycle
+cp docs/skills/pr-review-cycle.md ~/.codex/skills/pr-review-cycle/SKILL.md
+```
+
+### Claude-style skill directory
+
+```bash
+mkdir -p ~/.claude/skills/pr-review-cycle
+cp docs/skills/pr-review-cycle.md ~/.claude/skills/pr-review-cycle/SKILL.md
+```
+
+Use the Japanese template if preferred:
+
+```bash
+cp docs/skills/pr-review-cycle.ja.md ~/.codex/skills/pr-review-cycle/SKILL.md
+```
+
+After copying, edit the placeholders in the skill if your client exposes different tool prefixes:
+
+| Placeholder | Meaning |
+|---|---|
+| `{CRM}` | `copilot-review-mcp` tools |
+| `{GH}` | GitHub MCP tools used for comments, CI, and PR operations |
+
+## 6. Basic review-cycle usage
+
+Prerequisites:
+
+- `copilot-review-mcp` is running and connected in the MCP client.
+- A GitHub MCP server or GitHub connector is also available.
+- The current repository has an open PR.
+
+Typical instruction to the agent:
+
+```text
+$pr-review-cycle
+```
+
+The skill should:
+
+1. Check or request a Copilot review.
+2. Wait for completion with async watch.
+3. Fetch review threads.
+4. Classify comments.
+5. Apply accepted changes.
+6. Reply and resolve threads when remote side effects are allowed.
+7. Check CI and coverage.
+
+Merging remains a separate explicit user decision.
+
+## Troubleshooting
+
+### `redirect_uri host not permitted`
+
+The MCP client sent a redirect URI whose host is not allowed by the server. For local usage, use `localhost`, `127.0.0.1`, or `vscode.dev`. Hosted Claude Web usage requires the redirect-host configuration tracked in #6.
+
+### `invalid_token`
+
+Re-run the OAuth flow in the MCP client. If the token was revoked in GitHub, the client must authenticate again.
+
+### `session_user_mismatch`
+
+The same MCP session ID was reused with a different GitHub login. Clear the MCP client's cached session or reconnect.
+
+### Container starts but `/health` fails
+
+Check logs:
+
+```bash
+docker logs copilot-review-mcp
+```
+
+Common causes are missing `GITHUB_CLIENT_ID`, missing `GITHUB_CLIENT_SECRET`, or a port already in use.

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -112,7 +112,7 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration, inv TokenInva
 	// fully initialized, so watchManager is always non-nil.
 	var watchManager *watch.Manager
 	srv := mcp.NewServer(
-		&mcp.Implementation{Name: "copilot-review-mcp", Version: "2.4.0"},
+		&mcp.Implementation{Name: "copilot-review-mcp", Version: "2.5.0"},
 		&mcp.ServerOptions{
 			SchemaCache: schemaCache,
 			SubscribeHandler: func(ctx context.Context, req *mcp.SubscribeRequest) error {


### PR DESCRIPTION
## Summary

Prepares the repository for the `v2.5.0` release before the release PR review cycle.

## Changes

- Set the MCP implementation version to `2.5.0`.
- Move changelog content from `Unreleased` into `2.5.0 - 2026-04-26` in English and Japanese.
- Add `docs/usage.md` and `docs/usage.ja.md` with basic setup and operation guidance:
  - GitHub OAuth App settings
  - Docker pull/build/run/logs/stop/start/remove
  - MCP client configuration examples
  - `pr-review-cycle` skill installation examples
  - basic review-cycle usage and troubleshooting
- Link the usage docs from `README.md` and `README.ja.md`.

## Release Notes Included

This PR treats `v2.5.0` as the first standalone repository release while preserving continuity from the previous `copilot-review-mcp` service work in Mcp-Docker.

## Validation

- `go test ./...` passed
- `git diff --check` passed

## Notes

- This PR is intentionally draft. Copilot review request and the review-response cycle are left for the next LLM handoff.
- No release tag has been created yet.