### PR TITLE
docs: fix incorrect skill install path ~/.codex → ~/.claude

### DIFF
--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -231,7 +231,7 @@ cp docs/skills/pr-review-cycle.ja.md ~/.claude/skills/pr-review-cycle/SKILL.md
 英語版を使う場合:
 
 ```bash
-cp docs/skills/pr-review-cycle.md ~/.codex/skills/pr-review-cycle/SKILL.md
+cp docs/skills/pr-review-cycle.md ~/.claude/skills/pr-review-cycle/SKILL.md
 ```
 
 コピー後、利用中のクライアントで tool prefix が異なる場合は skill 内のプレースホルダーを修正する。

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -231,7 +231,7 @@ cp docs/skills/pr-review-cycle.md ~/.claude/skills/pr-review-cycle/SKILL.md
 Use the Japanese template if preferred:
 
 ```bash
-cp docs/skills/pr-review-cycle.ja.md ~/.codex/skills/pr-review-cycle/SKILL.md
+cp docs/skills/pr-review-cycle.ja.md ~/.claude/skills/pr-review-cycle/SKILL.md
 ```
 
 After copying, edit the placeholders in the skill if your client exposes different tool prefixes:


### PR DESCRIPTION
## Summary

- `docs/usage.md` L234: copy destination `~/.codex/...` → `~/.claude/...`
- `docs/usage.ja.md` L234: 同上（日本語版）

## Background

Copilot review of PR #8 flagged this path as incorrect. The fix was committed locally during the review cycle but was not pushed before the PR was merged. This hotfix applies the same change via a separate PR as required by branch protection rules.

## Test plan
- [ ] Documentation-only change, no code to test