### PR TITLE
feat: AUTH_MODE=gateway 対応（mcp-gateway 経由モード・二重検証の排除）

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,6 +9,11 @@
 
 ## [Unreleased]
 
+### 追加
+
+- `AUTH_MODE=gateway` 対応: `gateway` に設定すると、auth ミドルウェアが上流プロキシ（例: mcp-gateway）から注入された `X-Authenticated-User` ヘッダーを信頼し、GitHub API によるトークン検証をスキップする（二重検証の排除）
+- `AUTH_MODE=gateway` 時は `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` が不要になった
+
 ## [2.5.0] - 2026-04-26
 
 ### 追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `AUTH_MODE=gateway` support: when set to `gateway`, the auth middleware trusts the `X-Authenticated-User` header injected by an upstream proxy (e.g. mcp-gateway) and skips GitHub API token validation, eliminating double-validation overhead
+- `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` are no longer required when `AUTH_MODE=gateway`
+
 ## [2.5.0] - 2026-04-26
 
 ### Added

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -41,7 +41,11 @@ func main() {
 		ExpiresIn:          time.Duration(cfg.tokenExpiresInSec) * time.Second,
 	})
 
-	authMiddleware := middleware.Auth(oauthHandler)
+	if cfg.authMode == middleware.AuthModeGateway {
+		slog.Info("auth mode: gateway (trusting X-Authenticated-User header)")
+	}
+
+	authMiddleware := middleware.Auth(oauthHandler, cfg.authMode)
 
 	mux := http.NewServeMux()
 
@@ -88,6 +92,7 @@ func main() {
 type config struct {
 	githubClientID         string
 	githubClientSecret     string
+	authMode               middleware.AuthMode
 	baseURL                string
 	oauthScopes            string
 	port                   string
@@ -100,9 +105,26 @@ type config struct {
 }
 
 func loadConfig() config {
+	mode := middleware.AuthMode(getEnv("AUTH_MODE", string(middleware.AuthModeStandalone)))
+	if mode != middleware.AuthModeStandalone && mode != middleware.AuthModeGateway {
+		slog.Error("invalid AUTH_MODE value", "value", mode, "allowed", []string{string(middleware.AuthModeStandalone), string(middleware.AuthModeGateway)})
+		os.Exit(1)
+	}
+
+	var clientID, clientSecret string
+	if mode == middleware.AuthModeGateway {
+		// In gateway mode, GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are not required.
+		clientID = getEnv("GITHUB_CLIENT_ID", "")
+		clientSecret = getEnv("GITHUB_CLIENT_SECRET", "")
+	} else {
+		clientID = mustEnv("GITHUB_CLIENT_ID")
+		clientSecret = mustEnv("GITHUB_CLIENT_SECRET")
+	}
+
 	c := config{
-		githubClientID:         mustEnv("GITHUB_CLIENT_ID"),
-		githubClientSecret:     mustEnv("GITHUB_CLIENT_SECRET"),
+		githubClientID:         clientID,
+		githubClientSecret:     clientSecret,
+		authMode:               mode,
 		baseURL:                getEnv("BASE_URL", "http://localhost:8083"),
 		oauthScopes:            getEnv("GITHUB_OAUTH_SCOPES", "repo,user"),
 		port:                   getEnv("MCP_PORT", "8083"),

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -49,12 +49,26 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	// OAuth façade endpoints (no auth required)
-	mux.HandleFunc("GET /.well-known/oauth-authorization-server", oauthHandler.Discovery)
-	mux.HandleFunc("GET /authorize", oauthHandler.Authorize)
-	mux.HandleFunc("GET /callback", oauthHandler.Callback)
-	mux.HandleFunc("POST /token", oauthHandler.Token)
-	mux.HandleFunc("POST /register", oauthHandler.Register)
+	if cfg.authMode == middleware.AuthModeGateway {
+		// In gateway mode, OAuth endpoints are unused; return 410 Gone with an explanation.
+		goneHandler := func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusGone)
+			_, _ = fmt.Fprintln(w, `{"error":"oauth_unavailable","detail":"OAuth endpoints are disabled in AUTH_MODE=gateway"}`)
+		}
+		mux.HandleFunc("GET /.well-known/oauth-authorization-server", goneHandler)
+		mux.HandleFunc("GET /authorize", goneHandler)
+		mux.HandleFunc("GET /callback", goneHandler)
+		mux.HandleFunc("POST /token", goneHandler)
+		mux.HandleFunc("POST /register", goneHandler)
+	} else {
+		// OAuth façade endpoints (no auth required)
+		mux.HandleFunc("GET /.well-known/oauth-authorization-server", oauthHandler.Discovery)
+		mux.HandleFunc("GET /authorize", oauthHandler.Authorize)
+		mux.HandleFunc("GET /callback", oauthHandler.Callback)
+		mux.HandleFunc("POST /token", oauthHandler.Token)
+		mux.HandleFunc("POST /register", oauthHandler.Register)
+	}
 
 	// Health check (no auth required)
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -15,6 +15,17 @@ type contextKey string
 const ContextKeyLogin contextKey = "github_login"
 const ContextKeyToken contextKey = "github_token"
 
+// AuthMode controls how the auth middleware validates requests.
+type AuthMode string
+
+const (
+	// AuthModeStandalone is the default mode: validates Bearer tokens via the GitHub API.
+	AuthModeStandalone AuthMode = "standalone"
+	// AuthModeGateway trusts the X-Authenticated-User header injected by an upstream proxy
+	// (e.g. mcp-gateway). GitHub API validation is skipped.
+	AuthModeGateway AuthMode = "gateway"
+)
+
 // TokenValidator is implemented by auth.Handler.
 type TokenValidator interface {
 	ValidateToken(ctx context.Context, token string) (string, error)
@@ -27,9 +38,24 @@ type upstreamErrorer interface {
 }
 
 // Auth returns a middleware that validates Bearer tokens via the GitHub API.
-func Auth(v TokenValidator) func(http.Handler) http.Handler {
+// When mode is AuthModeGateway, trusts X-Authenticated-User injected by an upstream proxy
+// and skips token validation against the GitHub API.
+func Auth(v TokenValidator, mode AuthMode) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if mode == AuthModeGateway {
+				login := r.Header.Get("X-Authenticated-User")
+				if login == "" {
+					writeUnauthorized(w, "missing_proxy_identity")
+					return
+				}
+				token := extractBearer(r)
+				ctx := context.WithValue(r.Context(), ContextKeyLogin, login)
+				ctx = context.WithValue(ctx, ContextKeyToken, token)
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+
 			token := extractBearer(r)
 			if token == "" {
 				writeUnauthorized(w, "missing_token")

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -50,6 +50,10 @@ func Auth(v TokenValidator, mode AuthMode) func(http.Handler) http.Handler {
 					return
 				}
 				token := extractBearer(r)
+				if token == "" {
+					writeUnauthorized(w, "missing_token")
+					return
+				}
 				ctx := context.WithValue(r.Context(), ContextKeyLogin, login)
 				ctx = context.WithValue(ctx, ContextKeyToken, token)
 				next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -89,11 +89,9 @@ func TestAuth_GatewayMode(t *testing.T) {
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
-			name:           "valid proxy identity without bearer",
-			proxyLogin:     "bob",
-			wantStatus:     http.StatusOK,
-			wantLogin:      "bob",
-			wantTokenInCtx: "",
+			name:       "valid proxy identity without bearer returns 401",
+			proxyLogin: "bob",
+			wantStatus: http.StatusUnauthorized,
 		},
 		{
 			name:           "valid proxy identity with bearer token propagated to context",

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -1,0 +1,150 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// stubValidator is a minimal TokenValidator for testing.
+type stubValidator struct {
+	login string
+	err   error
+}
+
+func (s *stubValidator) ValidateToken(_ context.Context, _ string) (string, error) {
+	return s.login, s.err
+}
+
+func TestAuth_StandaloneMode(t *testing.T) {
+	tests := []struct {
+		name           string
+		authHeader     string
+		validatorLogin string
+		validatorErr   error
+		wantStatus     int
+		wantLogin      string
+	}{
+		{
+			name:       "missing token",
+			authHeader: "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "valid token",
+			authHeader:     "Bearer my-token",
+			validatorLogin: "alice",
+			wantStatus:     http.StatusOK,
+			wantLogin:      "alice",
+		},
+		{
+			name:         "invalid token",
+			authHeader:   "Bearer bad-token",
+			validatorErr: errFakeInvalid,
+			wantStatus:   http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &stubValidator{login: tt.validatorLogin, err: tt.validatorErr}
+			mw := Auth(v, AuthModeStandalone)
+
+			var capturedLogin string
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedLogin = LoginFromContext(r.Context())
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			mw(next).ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if tt.wantLogin != "" && capturedLogin != tt.wantLogin {
+				t.Fatalf("login = %q, want %q", capturedLogin, tt.wantLogin)
+			}
+		})
+	}
+}
+
+func TestAuth_GatewayMode(t *testing.T) {
+	tests := []struct {
+		name           string
+		proxyLogin     string
+		authHeader     string
+		wantStatus     int
+		wantLogin      string
+		wantTokenInCtx string
+	}{
+		{
+			name:       "missing X-Authenticated-User returns 401",
+			proxyLogin: "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "valid proxy identity without bearer",
+			proxyLogin:     "bob",
+			wantStatus:     http.StatusOK,
+			wantLogin:      "bob",
+			wantTokenInCtx: "",
+		},
+		{
+			name:           "valid proxy identity with bearer token propagated to context",
+			proxyLogin:     "carol",
+			authHeader:     "Bearer proxy-token",
+			wantStatus:     http.StatusOK,
+			wantLogin:      "carol",
+			wantTokenInCtx: "proxy-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// In gateway mode, the validator should never be called.
+			v := &stubValidator{err: errShouldNotCall}
+			mw := Auth(v, AuthModeGateway)
+
+			var capturedLogin, capturedToken string
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedLogin = LoginFromContext(r.Context())
+				capturedToken = TokenFromContext(r.Context())
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+			if tt.proxyLogin != "" {
+				req.Header.Set("X-Authenticated-User", tt.proxyLogin)
+			}
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			mw(next).ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if tt.wantLogin != "" && capturedLogin != tt.wantLogin {
+				t.Fatalf("login = %q, want %q", capturedLogin, tt.wantLogin)
+			}
+			if capturedToken != tt.wantTokenInCtx {
+				t.Fatalf("token in context = %q, want %q", capturedToken, tt.wantTokenInCtx)
+			}
+		})
+	}
+}
+
+// errFakeInvalid is a sentinel error representing an invalid-token validation failure.
+type fakeError struct{ msg string }
+
+func (e fakeError) Error() string { return e.msg }
+
+var errFakeInvalid = fakeError{"invalid token"}
+var errShouldNotCall = fakeError{"validator should not be called in gateway mode"}


### PR DESCRIPTION
## 概要

ISSUE #12 の実装。`AUTH_MODE=gateway` 環境変数を追加し、mcp-gateway 経由モードを最適化する。

## 変更内容

### `internal/middleware/auth.go`
- `AuthMode` 型と `AuthModeStandalone` / `AuthModeGateway` 定数を追加
- `Auth()` 関数に `mode AuthMode` パラメータを追加
- `AuthModeGateway` 時は `X-Authenticated-User` ヘッダーを信頼し、GitHub API 検証をスキップ

### `cmd/server/main.go`
- `config` 構造体に `authMode` フィールドを追加
- `loadConfig()` で `AUTH_MODE` 環境変数を読み込み
- `AUTH_MODE=gateway` 時は `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` が不要

### `internal/middleware/auth_test.go` (新規)
- standalone モードの単体テスト（missing token / valid token / invalid token）
- gateway モードの単体テスト（missing header / no bearer / with bearer）

## 後方互換性

| AUTH_MODE | 動作 |
|---|---|
| 未設定（デフォルト） | 従来通り（standalone OAuth） |
| `standalone` | 従来通り（明示指定） |
| `gateway` | `X-Authenticated-User` を信頼、GITHUB_CLIENT_ID/SECRET 不要 |

## セキュリティ考慮事項

`AUTH_MODE=gateway` は Docker 内部ネットワーク等でアクセス元を mcp-gateway のみに制限した環境での使用を前提とする。

Closes #12