### PR TITLE
chore(release): v3.0.0

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,6 +9,8 @@
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-05-06
+
 ### 削除
 
 - **スタンドアロン GitHub OAuth App フローを完全削除。** `internal/auth` パッケージ（handler、session、token cache）を削除。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-05-06
+
 ### Removed
 
 - **Standalone GitHub OAuth App flow removed entirely.** `internal/auth` package (handler, session, token cache) deleted.


### PR DESCRIPTION
## v3.0.0 リリース

### 変更内容

CHANGELOG の \[Unreleased]\ セクションを \[3.0.0] - 2026-05-06\ に確定。

### このリリースのハイライト

- **BREAKING**: スタンドアロン GitHub OAuth を完全削除（\internal/auth\ パッケージ削除）
- **必須**: 認証に [mcp-gateway](https://github.com/mcp-b/mcp-gateway) が必要
- OAuth エンドポイントは **410 Gone** を返すように変更
- \BIND_ADDR\ 環境変数を追加（デフォルト \127.0.0.1\、Docker では \