### PR TITLE
feat: return structured blocking errors for auth failures (closes #21)

### DIFF
--- a/internal/autherr/autherr.go
+++ b/internal/autherr/autherr.go
@@ -36,8 +36,8 @@ func (e *AuthError) Error() string {
 	return e.Message
 }
 
-// NewAuthRequired returns an AUTH_REQUIRED error for missing credentials.
-// Use when the request carries no GitHub token at all.
+// NewAuthRequired returns an AUTH_REQUIRED error for missing authentication context.
+// Use when the request carries no GitHub token or the user identity (login) is absent.
 func NewAuthRequired() *AuthError {
 	return &AuthError{
 		OK:                     false,
@@ -46,7 +46,7 @@ func NewAuthRequired() *AuthError {
 		Retryable:              false,
 		UserActionRequired:     true,
 		SafeToContinue:         false,
-		Message:                "GitHub authentication credentials are missing. Please provide a valid token before continuing.",
+		Message:                "GitHub authentication context is missing. Please sign in with a valid GitHub account before continuing.",
 		RecommendedAgentAction: "Stop the current operation and ask the user to provide GitHub authentication credentials.",
 	}
 }

--- a/internal/autherr/autherr.go
+++ b/internal/autherr/autherr.go
@@ -1,0 +1,92 @@
+// Package autherr defines structured authentication errors for MCP tool responses.
+// These errors signal to AI agents that the review cycle cannot safely continue
+// and that user action (re-authentication) is required.
+package autherr
+
+import "errors"
+
+// AuthErrorType identifies the category of authentication error.
+type AuthErrorType string
+
+const (
+	// AUTH_REQUIRED is returned when no authentication credentials exist.
+	AUTH_REQUIRED AuthErrorType = "AUTH_REQUIRED"
+	// REAUTH_REQUIRED is returned when credentials have expired or been rejected.
+	REAUTH_REQUIRED AuthErrorType = "REAUTH_REQUIRED"
+	// TOKEN_REFRESH_FAILED is returned when a token refresh attempt has failed.
+	TOKEN_REFRESH_FAILED AuthErrorType = "TOKEN_REFRESH_FAILED"
+)
+
+// AuthError is a structured blocking error returned when authentication fails.
+// It implements the error interface and serializes to JSON for AI agent consumption.
+// All auth errors are non-retryable and require explicit user action.
+type AuthError struct {
+	OK                     bool          `json:"ok"`
+	ErrorType              AuthErrorType `json:"error_type"`
+	Severity               string        `json:"severity"`
+	Retryable              bool          `json:"retryable"`
+	UserActionRequired     bool          `json:"user_action_required"`
+	SafeToContinue         bool          `json:"safe_to_continue"`
+	Message                string        `json:"message"`
+	RecommendedAgentAction string        `json:"recommended_agent_action"`
+}
+
+// Error implements the error interface.
+func (e *AuthError) Error() string {
+	return e.Message
+}
+
+// NewAuthRequired returns an AUTH_REQUIRED error for missing credentials.
+// Use when the request carries no GitHub token at all.
+func NewAuthRequired() *AuthError {
+	return &AuthError{
+		OK:                     false,
+		ErrorType:              AUTH_REQUIRED,
+		Severity:               "blocking",
+		Retryable:              false,
+		UserActionRequired:     true,
+		SafeToContinue:         false,
+		Message:                "GitHub authentication credentials are missing. Please provide a valid token before continuing.",
+		RecommendedAgentAction: "Stop the current operation and ask the user to provide GitHub authentication credentials.",
+	}
+}
+
+// NewReauthRequired returns a REAUTH_REQUIRED error for expired or rejected credentials.
+// Use when GitHub responds with HTTP 401 Unauthorized.
+func NewReauthRequired() *AuthError {
+	return &AuthError{
+		OK:                     false,
+		ErrorType:              REAUTH_REQUIRED,
+		Severity:               "blocking",
+		Retryable:              false,
+		UserActionRequired:     true,
+		SafeToContinue:         false,
+		Message:                "GitHub authentication has expired. Please re-authenticate before continuing.",
+		RecommendedAgentAction: "Stop the review cycle and ask the user to re-authenticate.",
+	}
+}
+
+// NewTokenRefreshFailed returns a TOKEN_REFRESH_FAILED error when token refresh fails.
+// Use when a gateway or OAuth refresh attempt is explicitly rejected.
+func NewTokenRefreshFailed() *AuthError {
+	return &AuthError{
+		OK:                     false,
+		ErrorType:              TOKEN_REFRESH_FAILED,
+		Severity:               "blocking",
+		Retryable:              false,
+		UserActionRequired:     true,
+		SafeToContinue:         false,
+		Message:                "GitHub token refresh failed. Please re-authenticate before continuing.",
+		RecommendedAgentAction: "Stop the review cycle and ask the user to re-authenticate.",
+	}
+}
+
+// AsAuthError reports whether err (or any wrapped error) is an *AuthError.
+// Returns the *AuthError and true if found, otherwise nil and false.
+func AsAuthError(err error) (*AuthError, bool) {
+	var ae *AuthError
+	if errors.As(err, &ae) {
+		return ae, true
+	}
+	return nil, false
+}

--- a/internal/autherr/autherr_test.go
+++ b/internal/autherr/autherr_test.go
@@ -1,0 +1,123 @@
+package autherr_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/scottlz0310/copilot-review-mcp/internal/autherr"
+)
+
+func TestAuthErrorImplementsError(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func() *autherr.AuthError
+	}{
+		{"NewAuthRequired", autherr.NewAuthRequired},
+		{"NewReauthRequired", autherr.NewReauthRequired},
+		{"NewTokenRefreshFailed", autherr.NewTokenRefreshFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ae := tt.fn()
+			var err error = ae // must satisfy error interface
+			if err.Error() == "" {
+				t.Error("Error() must not be empty")
+			}
+		})
+	}
+}
+
+func TestAuthErrorFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		fn            func() *autherr.AuthError
+		wantErrorType autherr.AuthErrorType
+	}{
+		{"NewAuthRequired", autherr.NewAuthRequired, autherr.AUTH_REQUIRED},
+		{"NewReauthRequired", autherr.NewReauthRequired, autherr.REAUTH_REQUIRED},
+		{"NewTokenRefreshFailed", autherr.NewTokenRefreshFailed, autherr.TOKEN_REFRESH_FAILED},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ae := tt.fn()
+
+			if ae.OK {
+				t.Error("OK must be false for auth errors")
+			}
+			if ae.ErrorType != tt.wantErrorType {
+				t.Errorf("ErrorType = %q, want %q", ae.ErrorType, tt.wantErrorType)
+			}
+			if ae.Severity != "blocking" {
+				t.Errorf("Severity = %q, want %q", ae.Severity, "blocking")
+			}
+			if ae.Retryable {
+				t.Error("Retryable must be false")
+			}
+			if !ae.UserActionRequired {
+				t.Error("UserActionRequired must be true")
+			}
+			if ae.SafeToContinue {
+				t.Error("SafeToContinue must be false")
+			}
+			if ae.Message == "" {
+				t.Error("Message must not be empty")
+			}
+			if ae.RecommendedAgentAction == "" {
+				t.Error("RecommendedAgentAction must not be empty")
+			}
+		})
+	}
+}
+
+func TestAsAuthError(t *testing.T) {
+	t.Run("direct auth error", func(t *testing.T) {
+		ae := autherr.NewAuthRequired()
+		got, ok := autherr.AsAuthError(ae)
+		if !ok {
+			t.Fatal("AsAuthError() ok = false, want true")
+		}
+		if got.ErrorType != autherr.AUTH_REQUIRED {
+			t.Errorf("ErrorType = %q, want %q", got.ErrorType, autherr.AUTH_REQUIRED)
+		}
+	})
+
+	t.Run("wrapped auth error is detected", func(t *testing.T) {
+		ae := autherr.NewReauthRequired()
+		wrapped := fmt.Errorf("outer: %w", ae)
+		got, ok := autherr.AsAuthError(wrapped)
+		if !ok {
+			t.Fatal("AsAuthError() ok = false for wrapped error, want true")
+		}
+		if got.ErrorType != autherr.REAUTH_REQUIRED {
+			t.Errorf("ErrorType = %q, want %q", got.ErrorType, autherr.REAUTH_REQUIRED)
+		}
+	})
+
+	t.Run("non-auth error returns false", func(t *testing.T) {
+		err := errors.New("some other error")
+		_, ok := autherr.AsAuthError(err)
+		if ok {
+			t.Fatal("AsAuthError() ok = true for non-auth error, want false")
+		}
+	})
+
+	t.Run("nil error returns false", func(t *testing.T) {
+		_, ok := autherr.AsAuthError(nil)
+		if ok {
+			t.Fatal("AsAuthError() ok = true for nil, want false")
+		}
+	})
+}
+
+func TestAuthErrorTypes(t *testing.T) {
+	if autherr.AUTH_REQUIRED != "AUTH_REQUIRED" {
+		t.Errorf("AUTH_REQUIRED = %q, want %q", autherr.AUTH_REQUIRED, "AUTH_REQUIRED")
+	}
+	if autherr.REAUTH_REQUIRED != "REAUTH_REQUIRED" {
+		t.Errorf("REAUTH_REQUIRED = %q, want %q", autherr.REAUTH_REQUIRED, "REAUTH_REQUIRED")
+	}
+	if autherr.TOKEN_REFRESH_FAILED != "TOKEN_REFRESH_FAILED" {
+		t.Errorf("TOKEN_REFRESH_FAILED = %q, want %q", autherr.TOKEN_REFRESH_FAILED, "TOKEN_REFRESH_FAILED")
+	}
+}

--- a/internal/github/auth_error_test.go
+++ b/internal/github/auth_error_test.go
@@ -1,0 +1,60 @@
+package ghclient
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v85/github"
+)
+
+func TestIsAuthError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "REST 401 error response",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusUnauthorized},
+			},
+			want: true,
+		},
+		{
+			name: "REST non-401 error response",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusForbidden},
+			},
+			want: false,
+		},
+		{
+			name: "githubv4 plain 401 error string",
+			err:  errors.New("non-200 OK status code: 401 Unauthorized body: {\"message\":\"Bad credentials\"}"),
+			want: true,
+		},
+		{
+			name: "nearby non-401 error string",
+			err:  errors.New("non-200 OK status code: 403 Forbidden body: {\"message\":\"Resource not accessible\"}"),
+			want: false,
+		},
+		{
+			name: "generic non-auth error",
+			err:  errors.New("network timeout"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAuthError(tt.err); got != tt.want {
+				t.Fatalf("IsAuthError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v85/github"
@@ -309,9 +310,19 @@ func DeriveStatusWithThreshold(_ time.Duration, data *ReviewData, requestedAt *t
 }
 
 // IsAuthError reports whether err is a GitHub authentication failure.
+// It handles both REST API errors (*github.ErrorResponse with HTTP 401) and
+// GraphQL errors from shurcooL/githubv4 whose message contains "401 Unauthorized".
 func IsAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
 	var ghErr *github.ErrorResponse
-	return errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusUnauthorized
+	if errors.As(err, &ghErr) {
+		return ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusUnauthorized
+	}
+	// shurcooL/githubv4 returns a plain error with the message
+	// "non-200 OK status code: 401 Unauthorized body: ..." for HTTP 401.
+	return strings.Contains(err.Error(), "401 Unauthorized")
 }
 
 // prNodeIDQuery fetches the GraphQL node ID for a pull request.

--- a/internal/tools/auth_error_test.go
+++ b/internal/tools/auth_error_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/scottlz0310/copilot-review-mcp/internal/autherr"
 	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
 	"github.com/scottlz0310/copilot-review-mcp/internal/store"
+	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
 )
 
 // errorProvider returns a githubClientProvider that always returns the given error.
@@ -199,6 +200,62 @@ func TestGetReviewThreadsHandlerReauthRequired(t *testing.T) {
 	handler := getReviewThreadsHandler(staticProvider(make401GitHubClient(srv)))
 	result, _, err := handler(context.Background(), nil, GetReviewThreadsInput{Owner: "o", Repo: "r", PR: 1})
 	assertAuthResult(t, result, err, autherr.REAUTH_REQUIRED)
+}
+
+// ── watch handler AUTH_REQUIRED tests ──
+
+// newMinimalWatchManager returns a watch.Manager for unit tests.
+// It uses an in-memory DB and no background polling.
+func newMinimalWatchManager(t *testing.T) *watch.Manager {
+	t.Helper()
+	db := openWatchToolsTestDB(t)
+	return watch.NewManager(db, watch.Options{Threshold: 30 * time.Second})
+}
+
+func TestStartWatchHandlerAuthRequired(t *testing.T) {
+	manager := newMinimalWatchManager(t)
+	handler := startWatchHandler(manager)
+	// nil request → no token/login in context → AUTH_REQUIRED
+	result, _, err := handler(context.Background(), nil, StartReviewWatchInput{Owner: "o", Repo: "r", PR: 1})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+func TestGetWatchStatusHandlerAuthRequired(t *testing.T) {
+	manager := newMinimalWatchManager(t)
+	handler := getWatchStatusHandler(manager)
+	result, _, err := handler(context.Background(), nil, GetReviewWatchStatusInput{WatchID: "some-id"})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+func TestListWatchesHandlerAuthRequired(t *testing.T) {
+	manager := newMinimalWatchManager(t)
+	handler := listWatchesHandler(manager)
+	result, _, err := handler(context.Background(), nil, ListReviewWatchesInput{})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+func TestCancelWatchHandlerAuthRequired(t *testing.T) {
+	manager := newMinimalWatchManager(t)
+	handler := cancelWatchHandler(manager)
+	result, _, err := handler(context.Background(), nil, CancelReviewWatchInput{WatchID: "some-id"})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+// ── StructuredContent is populated ──
+
+func TestAuthErrResultHasStructuredContent(t *testing.T) {
+	ae := autherr.NewReauthRequired()
+	result := authErrResult(ae)
+	if result.StructuredContent == nil {
+		t.Fatal("StructuredContent is nil, want *autherr.AuthError")
+	}
+	sc, ok := result.StructuredContent.(*autherr.AuthError)
+	if !ok {
+		t.Fatalf("StructuredContent type = %T, want *autherr.AuthError", result.StructuredContent)
+	}
+	if sc.ErrorType != autherr.REAUTH_REQUIRED {
+		t.Errorf("StructuredContent.ErrorType = %q, want %q", sc.ErrorType, autherr.REAUTH_REQUIRED)
+	}
 }
 
 // ── tryAuthResult unit test ──

--- a/internal/tools/auth_error_test.go
+++ b/internal/tools/auth_error_test.go
@@ -3,10 +3,13 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -285,4 +288,72 @@ func TestTryAuthResult(t *testing.T) {
 			t.Error("tryAuthResult(context.Canceled) should return (nil, false)")
 		}
 	})
+}
+
+// newReplySucceedResolveFail401Server returns a server where ReplyToThread succeeds
+// but the resolveReviewThread GraphQL mutation returns 401 Unauthorized.
+func newReplySucceedResolveFail401Server(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// REST: CreateCommentInReplyTo — path starts with /repos/
+		if strings.HasPrefix(r.URL.Path, "/repos/") {
+			_, _ = fmt.Fprint(w, `{"id":999,"body":"reply"}`)
+			return
+		}
+
+		// GraphQL: distinguish queries by body content.
+		body, _ := io.ReadAll(r.Body)
+		bs := string(body)
+
+		switch {
+		case strings.Contains(bs, "resolveReviewThread"):
+			// Resolve mutation → 401
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"message":"Bad credentials"}`)
+		case strings.Contains(bs, "databaseId"):
+			// threadMetadataQuery → return minimal metadata
+			_, _ = fmt.Fprint(w, `{"data":{"node":{"pullRequest":{"number":1,"repository":{"name":"r","owner":{"login":"o"}}},"comments":{"nodes":[{"databaseId":42}]}}}}`)
+		default:
+			// threadNodeQuery (isResolved check) → not yet resolved
+			_, _ = fmt.Fprint(w, `{"data":{"node":{"isResolved":false}}}`)
+		}
+	}))
+	return srv
+}
+
+// TestReplyAndResolveHandlerResolveReauthRequired verifies that when the
+// resolveReviewThread mutation returns 401, the handler sets ResolveError to a
+// canonical REAUTH_REQUIRED string instead of a hard-coded message.
+func TestReplyAndResolveHandlerResolveReauthRequired(t *testing.T) {
+	srv := newReplySucceedResolveFail401Server(t)
+	t.Cleanup(srv.Close)
+
+	handler := replyAndResolveHandler(staticProvider(make401GitHubClient(srv)))
+	result, out, err := handler(
+		context.Background(), nil,
+		ReplyAndResolveInput{ThreadID: "PRRT_abc", Body: "hello", Resolve: true},
+	)
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("result = %v, want nil", result)
+	}
+	if !out.Replied {
+		t.Error("out.Replied = false, want true")
+	}
+	if out.CommentID == nil {
+		t.Error("out.CommentID = nil, want non-nil")
+	}
+	if out.Resolved {
+		t.Error("out.Resolved = true, want false")
+	}
+	if out.ResolveError == nil {
+		t.Fatal("out.ResolveError = nil, want REAUTH_REQUIRED error string")
+	}
+	if !strings.HasPrefix(*out.ResolveError, string(autherr.REAUTH_REQUIRED)) {
+		t.Errorf("ResolveError = %q, want prefix %q", *out.ResolveError, autherr.REAUTH_REQUIRED)
+	}
 }

--- a/internal/tools/auth_error_test.go
+++ b/internal/tools/auth_error_test.go
@@ -1,0 +1,231 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v85/github"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/shurcooL/githubv4"
+
+	"github.com/scottlz0310/copilot-review-mcp/internal/autherr"
+	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
+	"github.com/scottlz0310/copilot-review-mcp/internal/store"
+)
+
+// errorProvider returns a githubClientProvider that always returns the given error.
+func errorProvider(err error) githubClientProvider {
+	return func(_ context.Context, _ *mcp.CallToolRequest) (*ghclient.Client, error) {
+		return nil, err
+	}
+}
+
+// new401Server returns an httptest.Server that responds to every request with HTTP 401.
+func new401Server() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+}
+
+// make401GitHubClient creates a *ghclient.Client pointing at a server that returns 401.
+func make401GitHubClient(srv *httptest.Server) *ghclient.Client {
+	restClient := github.NewClient(srv.Client())
+	base, _ := url.Parse(srv.URL + "/")
+	restClient.BaseURL = base
+	restClient.UploadURL = base
+	gqlClient := githubv4.NewEnterpriseClient(srv.URL, srv.Client())
+	return ghclient.NewWithClients(restClient, gqlClient, 30*time.Second)
+}
+
+// decodeAuthError unmarshals the text content of a *mcp.CallToolResult into *autherr.AuthError.
+func decodeAuthError(t *testing.T, result *mcp.CallToolResult) *autherr.AuthError {
+	t.Helper()
+	if result == nil {
+		t.Fatal("result is nil")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("result.Content is empty")
+	}
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("result.Content[0] is %T, want *mcp.TextContent", result.Content[0])
+	}
+	var ae autherr.AuthError
+	if err := json.Unmarshal([]byte(tc.Text), &ae); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v, text = %s", err, tc.Text)
+	}
+	return &ae
+}
+
+// assertAuthResult checks that result is a non-nil auth error result with IsError set.
+func assertAuthResult(t *testing.T, result *mcp.CallToolResult, err error, wantType autherr.AuthErrorType) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("handler returned nil result, want structured auth error")
+	}
+	if !result.IsError {
+		t.Error("result.IsError = false, want true")
+	}
+	ae := decodeAuthError(t, result)
+	if ae.OK {
+		t.Error("AuthError.OK = true, want false")
+	}
+	if ae.ErrorType != wantType {
+		t.Errorf("AuthError.ErrorType = %q, want %q", ae.ErrorType, wantType)
+	}
+	if ae.Severity != "blocking" {
+		t.Errorf("AuthError.Severity = %q, want %q", ae.Severity, "blocking")
+	}
+	if ae.Retryable {
+		t.Error("AuthError.Retryable = true, want false")
+	}
+	if !ae.UserActionRequired {
+		t.Error("AuthError.UserActionRequired = false, want true")
+	}
+	if ae.SafeToContinue {
+		t.Error("AuthError.SafeToContinue = true, want false")
+	}
+}
+
+// ── AUTH_REQUIRED tests (missing token → provider returns *autherr.AuthError) ──
+
+func TestStatusHandlerAuthRequired(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := statusHandler(errorProvider(autherr.NewAuthRequired()), db)
+	result, _, err := handler(context.Background(), nil, GetStatusInput{Owner: "o", Repo: "r", PR: 1})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+func TestRequestHandlerAuthRequired(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := requestHandler(errorProvider(autherr.NewAuthRequired()), db)
+	result, _, err := handler(context.Background(), nil, RequestInput{Owner: "o", Repo: "r", PR: 1})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+func TestGetReviewThreadsHandlerAuthRequired(t *testing.T) {
+	handler := getReviewThreadsHandler(errorProvider(autherr.NewAuthRequired()))
+	result, _, err := handler(context.Background(), nil, GetReviewThreadsInput{Owner: "o", Repo: "r", PR: 1})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+func TestReplyToThreadHandlerAuthRequired(t *testing.T) {
+	handler := replyToThreadHandler(errorProvider(autherr.NewAuthRequired()))
+	result, _, err := handler(context.Background(), nil, ReplyToThreadInput{ThreadID: "PRRT_abc", Body: "hello"})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+func TestResolveThreadHandlerAuthRequired(t *testing.T) {
+	handler := resolveThreadHandler(errorProvider(autherr.NewAuthRequired()))
+	result, _, err := handler(context.Background(), nil, ResolveThreadInput{ThreadID: "PRRT_abc"})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+func TestReplyAndResolveHandlerAuthRequired(t *testing.T) {
+	handler := replyAndResolveHandler(errorProvider(autherr.NewAuthRequired()))
+	result, _, err := handler(context.Background(), nil, ReplyAndResolveInput{ThreadID: "PRRT_abc", Body: "hello", Resolve: true})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+func TestWaitHandlerAuthRequired(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := waitHandler(errorProvider(autherr.NewAuthRequired()), db)
+	result, _, err := handler(context.Background(), nil, WaitInput{Owner: "o", Repo: "r", PR: 1, PollIntervalSeconds: 1, MaxPolls: 1})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+// ── REAUTH_REQUIRED tests (GitHub returns 401 → tryAuthResult wraps as REAUTH_REQUIRED) ──
+
+func TestStatusHandlerReauthRequired(t *testing.T) {
+	srv := new401Server()
+	t.Cleanup(srv.Close)
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := statusHandler(staticProvider(make401GitHubClient(srv)), db)
+	result, _, err := handler(context.Background(), nil, GetStatusInput{Owner: "o", Repo: "r", PR: 1})
+	assertAuthResult(t, result, err, autherr.REAUTH_REQUIRED)
+}
+
+func TestRequestHandlerReauthRequired(t *testing.T) {
+	srv := new401Server()
+	t.Cleanup(srv.Close)
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := requestHandler(staticProvider(make401GitHubClient(srv)), db)
+	result, _, err := handler(context.Background(), nil, RequestInput{Owner: "o", Repo: "r", PR: 1})
+	assertAuthResult(t, result, err, autherr.REAUTH_REQUIRED)
+}
+
+func TestGetReviewThreadsHandlerReauthRequired(t *testing.T) {
+	srv := new401Server()
+	t.Cleanup(srv.Close)
+
+	handler := getReviewThreadsHandler(staticProvider(make401GitHubClient(srv)))
+	result, _, err := handler(context.Background(), nil, GetReviewThreadsInput{Owner: "o", Repo: "r", PR: 1})
+	assertAuthResult(t, result, err, autherr.REAUTH_REQUIRED)
+}
+
+// ── tryAuthResult unit test ──
+
+func TestTryAuthResult(t *testing.T) {
+	t.Run("nil error returns false", func(t *testing.T) {
+		result, ok := tryAuthResult(nil)
+		if ok || result != nil {
+			t.Error("tryAuthResult(nil) should return (nil, false)")
+		}
+	})
+
+	t.Run("AUTH_REQUIRED error returns structured result", func(t *testing.T) {
+		result, ok := tryAuthResult(autherr.NewAuthRequired())
+		if !ok {
+			t.Fatal("tryAuthResult() ok = false for AUTH_REQUIRED error")
+		}
+		ae := decodeAuthError(t, result)
+		if ae.ErrorType != autherr.AUTH_REQUIRED {
+			t.Errorf("ErrorType = %q, want %q", ae.ErrorType, autherr.AUTH_REQUIRED)
+		}
+	})
+
+	t.Run("non-auth error returns false", func(t *testing.T) {
+		result, ok := tryAuthResult(context.Canceled)
+		if ok || result != nil {
+			t.Error("tryAuthResult(context.Canceled) should return (nil, false)")
+		}
+	})
+}

--- a/internal/tools/auth_request.go
+++ b/internal/tools/auth_request.go
@@ -2,13 +2,13 @@ package tools
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/scottlz0310/copilot-review-mcp/internal/autherr"
 	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
 	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
 )
@@ -19,7 +19,7 @@ func newGitHubClientProvider(threshold time.Duration, invalidate func(string)) g
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*ghclient.Client, error) {
 		token := tokenFromToolRequest(ctx, req)
 		if token == "" {
-			return nil, fmt.Errorf("authenticated GitHub token is required")
+			return nil, autherr.NewAuthRequired()
 		}
 		return ghclient.NewClient(ctx, token, threshold, invalidate), nil
 	}

--- a/internal/tools/auth_result.go
+++ b/internal/tools/auth_result.go
@@ -9,13 +9,16 @@ import (
 	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
 )
 
-// authErrResult converts an *autherr.AuthError into a *mcp.CallToolResult with JSON
-// text content. IsError is set to true so AI agents treat it as a blocking failure.
+// authErrResult converts an *autherr.AuthError into a *mcp.CallToolResult.
+// Content carries a JSON text representation and StructuredContent provides
+// the same data as a parsed object. IsError is set to true so AI agents
+// treat it as a blocking failure that requires user action.
 func authErrResult(ae *autherr.AuthError) *mcp.CallToolResult {
 	b, _ := json.Marshal(ae)
 	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
-		IsError: true,
+		Content:           []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		StructuredContent: ae,
+		IsError:           true,
 	}
 }
 

--- a/internal/tools/auth_result.go
+++ b/internal/tools/auth_result.go
@@ -1,0 +1,39 @@
+package tools
+
+import (
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/scottlz0310/copilot-review-mcp/internal/autherr"
+	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
+)
+
+// authErrResult converts an *autherr.AuthError into a *mcp.CallToolResult with JSON
+// text content. IsError is set to true so AI agents treat it as a blocking failure.
+func authErrResult(ae *autherr.AuthError) *mcp.CallToolResult {
+	b, _ := json.Marshal(ae)
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		IsError: true,
+	}
+}
+
+// tryAuthResult checks whether err represents an authentication failure and, if so,
+// returns a structured *mcp.CallToolResult and true.
+//
+// It handles:
+//   - *autherr.AuthError (e.g. AUTH_REQUIRED from the client provider)
+//   - GitHub HTTP 401 errors detected by ghclient.IsAuthError → REAUTH_REQUIRED
+func tryAuthResult(err error) (*mcp.CallToolResult, bool) {
+	if err == nil {
+		return nil, false
+	}
+	if ae, ok := autherr.AsAuthError(err); ok {
+		return authErrResult(ae), true
+	}
+	if ghclient.IsAuthError(err) {
+		return authErrResult(autherr.NewReauthRequired()), true
+	}
+	return nil, false
+}

--- a/internal/tools/auth_result.go
+++ b/internal/tools/auth_result.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -20,6 +21,23 @@ func authErrResult(ae *autherr.AuthError) *mcp.CallToolResult {
 		StructuredContent: ae,
 		IsError:           true,
 	}
+}
+
+// authErrString returns a canonical "<ErrorType>: <Message>" string for auth
+// errors. It mirrors tryAuthResult's detection logic but returns a plain string
+// suitable for embedding in output fields rather than a full MCP result.
+func authErrString(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	if ae, ok := autherr.AsAuthError(err); ok {
+		return fmt.Sprintf("%s: %s", ae.ErrorType, ae.Message), true
+	}
+	if ghclient.IsAuthError(err) {
+		ae := autherr.NewReauthRequired()
+		return fmt.Sprintf("%s: %s", ae.ErrorType, ae.Message), true
+	}
+	return "", false
 }
 
 // tryAuthResult checks whether err represents an authentication failure and, if so,

--- a/internal/tools/cycle.go
+++ b/internal/tools/cycle.go
@@ -116,6 +116,9 @@ func cycleStatusHandler(
 
 		gh, err := clientProvider(ctx, req)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, CycleStatusOutput{}, nil
+			}
 			return nil, CycleStatusOutput{}, err
 		}
 
@@ -137,6 +140,9 @@ func cycleStatusHandler(
 		// Auto-detect CI status early so all exit paths return accurate ci_ok.
 		ciAllSuccess, err := gh.GetCIStatus(ctx, in.Owner, in.Repo, in.PR)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, CycleStatusOutput{}, nil
+			}
 			return nil, CycleStatusOutput{}, fmt.Errorf("failed to get CI status: %w", err)
 		}
 
@@ -162,6 +168,9 @@ func cycleStatusHandler(
 		// ── Fetch review threads ─────────────────────────────────────────────
 		rawThreads, err := gh.GetReviewThreads(ctx, in.Owner, in.Repo, in.PR)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, CycleStatusOutput{}, nil
+			}
 			return nil, CycleStatusOutput{}, fmt.Errorf("failed to fetch review threads: %w", err)
 		}
 

--- a/internal/tools/cycle.go
+++ b/internal/tools/cycle.go
@@ -205,6 +205,9 @@ func cycleStatusHandler(
 		// ── Fetch current review status ──────────────────────────────────────
 		reviewData, err := gh.GetReviewData(ctx, in.Owner, in.Repo, in.PR)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, CycleStatusOutput{}, nil
+			}
 			return nil, CycleStatusOutput{}, fmt.Errorf("failed to fetch review data: %w", err)
 		}
 		if reviewData.RateLimitRemaining < 10 {

--- a/internal/tools/cycle_auth_error_test.go
+++ b/internal/tools/cycle_auth_error_test.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/scottlz0310/copilot-review-mcp/internal/autherr"
+	"github.com/scottlz0310/copilot-review-mcp/internal/store"
+)
+
+func TestCycleStatusHandlerAuthRequired(t *testing.T) {
+	db, err := store.Open(filepath.Join(t.TempDir(), "cycle-auth-required.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := cycleStatusHandler(errorProvider(autherr.NewAuthRequired()), db)
+	result, _, err := handler(context.Background(), nil, CycleStatusInput{
+		Owner:      "o",
+		Repo:       "r",
+		PR:         1,
+		CyclesDone: 0,
+		MaxCycles:  3,
+		FixType:    "none",
+	})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}
+
+func TestCycleStatusHandlerReauthRequired(t *testing.T) {
+	srv := new401Server()
+	t.Cleanup(srv.Close)
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "cycle-reauth-required.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := cycleStatusHandler(staticProvider(make401GitHubClient(srv)), db)
+	result, _, err := handler(context.Background(), nil, CycleStatusInput{
+		Owner:      "o",
+		Repo:       "r",
+		PR:         1,
+		CyclesDone: 0,
+		MaxCycles:  3,
+		FixType:    "none",
+	})
+	assertAuthResult(t, result, err, autherr.REAUTH_REQUIRED)
+}

--- a/internal/tools/request.go
+++ b/internal/tools/request.go
@@ -42,6 +42,9 @@ func requestHandler(
 		}
 		ghClient, err := clientProvider(ctx, req)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, RequestOutput{}, nil
+			}
 			return nil, RequestOutput{}, err
 		}
 
@@ -61,6 +64,9 @@ func requestHandler(
 		// Guard: also check the live GitHub reviewer list.
 		data, err := ghClient.GetReviewData(ctx, in.Owner, in.Repo, in.PR)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, RequestOutput{}, nil
+			}
 			return nil, RequestOutput{}, err
 		}
 
@@ -75,6 +81,9 @@ func requestHandler(
 
 		// Request the review via GitHub API.
 		if err := ghClient.RequestCopilotReview(ctx, in.Owner, in.Repo, in.PR); err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, RequestOutput{}, nil
+			}
 			return nil, RequestOutput{}, err
 		}
 

--- a/internal/tools/status.go
+++ b/internal/tools/status.go
@@ -49,11 +49,17 @@ func statusHandler(
 
 		ghClient, err := clientProvider(ctx, req)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, GetStatusOutput{}, nil
+			}
 			return nil, GetStatusOutput{}, err
 		}
 
 		data, err := ghClient.GetReviewData(ctx, in.Owner, in.Repo, in.PR)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, GetStatusOutput{}, nil
+			}
 			return nil, GetStatusOutput{}, err
 		}
 

--- a/internal/tools/threads.go
+++ b/internal/tools/threads.go
@@ -291,8 +291,10 @@ func replyAndResolveHandler(
 		}
 		_, err = gh.ResolveThread(ctx, in.ThreadID)
 		if err != nil {
-			if result, ok := tryAuthResult(err); ok {
-				return result, ReplyAndResolveOutput{}, nil
+			if _, ok := tryAuthResult(err); ok {
+				errStr := "resolve failed: re-authentication is required"
+				out.ResolveError = &errStr
+				return nil, out, nil
 			}
 			errStr := err.Error()
 			out.ResolveError = &errStr

--- a/internal/tools/threads.go
+++ b/internal/tools/threads.go
@@ -59,11 +59,17 @@ func getReviewThreadsHandler(
 		}
 		gh, err := clientProvider(ctx, req)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, GetReviewThreadsOutput{}, nil
+			}
 			return nil, GetReviewThreadsOutput{}, err
 		}
 
 		rawThreads, err := gh.GetReviewThreads(ctx, in.Owner, in.Repo, in.PR)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, GetReviewThreadsOutput{}, nil
+			}
 			return nil, GetReviewThreadsOutput{}, err
 		}
 
@@ -131,16 +137,25 @@ func replyToThreadHandler(
 		}
 		gh, err := clientProvider(ctx, req)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, ReplyToThreadOutput{}, nil
+			}
 			return nil, ReplyToThreadOutput{}, err
 		}
 
 		alreadyResolved, err := gh.IsThreadResolved(ctx, in.ThreadID)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, ReplyToThreadOutput{}, nil
+			}
 			return nil, ReplyToThreadOutput{}, err
 		}
 
 		result, err := gh.ReplyToThread(ctx, in.ThreadID, in.Body)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, ReplyToThreadOutput{}, nil
+			}
 			return nil, ReplyToThreadOutput{}, err
 		}
 
@@ -188,11 +203,17 @@ func resolveThreadHandler(
 		}
 		gh, err := clientProvider(ctx, req)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, ResolveThreadOutput{}, nil
+			}
 			return nil, ResolveThreadOutput{}, err
 		}
 
 		alreadyResolved, err := gh.ResolveThread(ctx, in.ThreadID)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, ResolveThreadOutput{}, nil
+			}
 			return nil, ResolveThreadOutput{}, err
 		}
 		return nil, ResolveThreadOutput{
@@ -242,6 +263,9 @@ func replyAndResolveHandler(
 		}
 		gh, err := clientProvider(ctx, req)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, ReplyAndResolveOutput{}, nil
+			}
 			return nil, ReplyAndResolveOutput{}, err
 		}
 
@@ -250,6 +274,9 @@ func replyAndResolveHandler(
 		// Step 1: Reply.
 		replyResult, err := gh.ReplyToThread(ctx, in.ThreadID, in.Body)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, ReplyAndResolveOutput{}, nil
+			}
 			errStr := err.Error()
 			out.ReplyError = &errStr
 			// replied == false → skip Resolve.
@@ -264,6 +291,9 @@ func replyAndResolveHandler(
 		}
 		_, err = gh.ResolveThread(ctx, in.ThreadID)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, ReplyAndResolveOutput{}, nil
+			}
 			errStr := err.Error()
 			out.ResolveError = &errStr
 			return nil, out, nil

--- a/internal/tools/threads.go
+++ b/internal/tools/threads.go
@@ -291,8 +291,7 @@ func replyAndResolveHandler(
 		}
 		_, err = gh.ResolveThread(ctx, in.ThreadID)
 		if err != nil {
-			if _, ok := tryAuthResult(err); ok {
-				errStr := "resolve failed: re-authentication is required"
+			if errStr, ok := authErrString(err); ok {
 				out.ResolveError = &errStr
 				return nil, out, nil
 			}

--- a/internal/tools/wait.go
+++ b/internal/tools/wait.go
@@ -77,6 +77,9 @@ func waitHandler(
 		start := time.Now()
 		ghClient, err := clientProvider(ctx, req)
 		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, WaitOutput{}, nil
+			}
 			return nil, WaitOutput{}, err
 		}
 
@@ -107,6 +110,9 @@ func waitHandler(
 			if err != nil {
 				if isCancellation(err) {
 					return nil, buildCancelledOutput(lastData, lastEntry, lastStatus, poll, time.Since(start)), nil
+				}
+				if result, ok := tryAuthResult(err); ok {
+					return result, WaitOutput{}, nil
 				}
 				return nil, WaitOutput{}, err
 			}

--- a/internal/tools/watch.go
+++ b/internal/tools/watch.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/scottlz0310/copilot-review-mcp/internal/autherr"
 	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
 	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
 )
@@ -146,7 +147,7 @@ func startWatchHandler(
 		login := loginFromToolRequest(ctx, req)
 		token := tokenFromToolRequest(ctx, req)
 		if login == "" || token == "" {
-			return nil, StartReviewWatchOutput{}, fmt.Errorf("authenticated GitHub login and token are required")
+			return authErrResult(autherr.NewAuthRequired()), StartReviewWatchOutput{}, nil
 		}
 
 		snapshot, reused, err := manager.Start(watch.StartInput{
@@ -176,7 +177,7 @@ func getWatchStatusHandler(
 	return func(ctx context.Context, req *mcp.CallToolRequest, in GetReviewWatchStatusInput) (*mcp.CallToolResult, GetReviewWatchStatusOutput, error) {
 		login := loginFromToolRequest(ctx, req)
 		if login == "" {
-			return nil, GetReviewWatchStatusOutput{}, fmt.Errorf("authenticated GitHub login is required")
+			return authErrResult(autherr.NewAuthRequired()), GetReviewWatchStatusOutput{}, nil
 		}
 
 		var (
@@ -213,7 +214,7 @@ func listWatchesHandler(
 	return func(ctx context.Context, req *mcp.CallToolRequest, in ListReviewWatchesInput) (*mcp.CallToolResult, ListReviewWatchesOutput, error) {
 		login := loginFromToolRequest(ctx, req)
 		if login == "" {
-			return nil, ListReviewWatchesOutput{}, fmt.Errorf("authenticated GitHub login is required")
+			return authErrResult(autherr.NewAuthRequired()), ListReviewWatchesOutput{}, nil
 		}
 		if in.Repo != "" && in.Owner == "" {
 			return nil, ListReviewWatchesOutput{}, fmt.Errorf("owner is required when repo is specified")
@@ -263,7 +264,7 @@ func cancelWatchHandler(
 	return func(ctx context.Context, req *mcp.CallToolRequest, in CancelReviewWatchInput) (*mcp.CallToolResult, CancelReviewWatchOutput, error) {
 		login := loginFromToolRequest(ctx, req)
 		if login == "" {
-			return nil, CancelReviewWatchOutput{}, fmt.Errorf("authenticated GitHub login is required")
+			return authErrResult(autherr.NewAuthRequired()), CancelReviewWatchOutput{}, nil
 		}
 
 		var (


### PR DESCRIPTION
Introduce internal/autherr package with three error types scoped to
this PR: AUTH_REQUIRED, REAUTH_REQUIRED, TOKEN_REFRESH_FAILED.

Each AuthError carries the fields required by the MCP tool contract:
  ok, error_type, severity (blocking), retryable (false),
  user_action_required (true), safe_to_continue (false),
  message, recommended_agent_action.

Changes:
- internal/autherr/autherr.go  – AuthError type, constructors, AsAuthError helper
- internal/tools/auth_result.go – authErrResult / tryAuthResult helpers that
  produce a *mcp.CallToolResult (IsError: true) with JSON text content
- internal/tools/auth_request.go – NewAuthRequired() when token is absent
- internal/github/client.go    – IsAuthError also catches GraphQL 401 strings
  from shurcooL/githubv4 (plain errorString "401 Unauthorized")
- All tool handlers (status, request, threads ×4, cycle, wait) detect auth
  errors from clientProvider and GitHub API calls via tryAuthResult and
  return the structured result instead of a raw error

Tests added:
- internal/autherr/autherr_test.go – unit tests for all constructors,
  field invariants, AsAuthError (direct, wrapped, nil, non-auth)
- internal/tools/auth_error_test.go – integration tests for AUTH_REQUIRED
  (via errorProvider) and REAUTH_REQUIRED (via 401 mock server) across
  all affected handlers; tryAuthResult unit tests

https://claude.ai/code/session_01Ep6XmYHuJKCp8xZMW1kKVr