### PR TITLE
feat(autherr): complete Issue #21 — 5 new structured error types + ClassifyGitHubError

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -22,7 +22,7 @@
 - **`ClassifyGitHubError(err error) *autherr.AuthError`** を `internal/github/client.go` に追加。REST `*github.ErrorResponse`、`*github.RateLimitError`、`*github.AbuseRateLimitError`、shurcooL/githubv4 の文字列マッチ、既分類済みの `*autherr.AuthError` を含む任意の GitHub API エラーを適切な構造化エラー型に変換する単一エントリポイント。
 - `internal/tools/auth_result.go` の `tryAuthResult` および `authErrString` が `IsAuthError` の代わりに `ClassifyGitHubError` を呼ぶようになり、8 種類のエラー型すべてに対してハンドラごとの変更なしに構造化エラーを返せるようになった。
 
-
+## [3.0.0] - 2026-05-06
 
 ### 削除
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,7 +9,20 @@
 
 ## [Unreleased]
 
-## [3.0.0] - 2026-05-06
+## [3.1.0] - 2026-05-09
+
+### 追加
+
+- **5 つの新しい構造化エラー型** を `internal/autherr` に追加し、[Issue #21](https://github.com/scottlz0310/copilot-review-mcp/issues/21) を完結:
+  - `PERMISSION_DENIED` — HTTP 403 レスポンス（rate limit 以外）
+  - `RATE_LIMITED` — プライマリ rate limit（`*github.RateLimitError`）とセカンダリ/abuse rate limit（`*github.AbuseRateLimitError`）。`retryable` と `safe_to_continue` は状況依存
+  - `NOT_FOUND` — HTTP 404 レスポンス
+  - `VALIDATION_ERROR` — HTTP 400 / 422 レスポンス
+  - `TRANSIENT_UPSTREAM_ERROR` — HTTP 5xx レスポンス（retryable）
+- **`ClassifyGitHubError(err error) *autherr.AuthError`** を `internal/github/client.go` に追加。REST `*github.ErrorResponse`、`*github.RateLimitError`、`*github.AbuseRateLimitError`、shurcooL/githubv4 の文字列マッチ、既分類済みの `*autherr.AuthError` を含む任意の GitHub API エラーを適切な構造化エラー型に変換する単一エントリポイント。
+- `internal/tools/auth_result.go` の `tryAuthResult` および `authErrString` が `IsAuthError` の代わりに `ClassifyGitHubError` を呼ぶようになり、8 種類のエラー型すべてに対してハンドラごとの変更なしに構造化エラーを返せるようになった。
+
+
 
 ### 削除
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0] - 2026-05-06
+## [3.1.0] - 2026-05-09
+
+### Added
+
+- **Five new structured error types** in `internal/autherr` completing [Issue #21](https://github.com/scottlz0310/copilot-review-mcp/issues/21):
+  - `PERMISSION_DENIED` — HTTP 403 responses (non-rate-limit)
+  - `RATE_LIMITED` — primary (`*github.RateLimitError`) and secondary/abuse (`*github.AbuseRateLimitError`) rate limits; `retryable` and `safe_to_continue` are situation-dependent
+  - `NOT_FOUND` — HTTP 404 responses
+  - `VALIDATION_ERROR` — HTTP 400 / 422 responses
+  - `TRANSIENT_UPSTREAM_ERROR` — HTTP 5xx responses (retryable)
+- **`ClassifyGitHubError(err error) *autherr.AuthError`** in `internal/github/client.go` — a single entry point that classifies any GitHub API error (REST `*github.ErrorResponse`, `*github.RateLimitError`, `*github.AbuseRateLimitError`, shurcooL/githubv4 string-matched errors, and already-classified `*autherr.AuthError`) into the appropriate structured error type.
+- `tryAuthResult` and `authErrString` in `internal/tools/auth_result.go` now call `ClassifyGitHubError` instead of `IsAuthError`, so all tool handlers automatically return structured errors for any of the 8 error types without additional per-handler changes.
+
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ClassifyGitHubError(err error) *autherr.AuthError`** in `internal/github/client.go` — a single entry point that classifies any GitHub API error (REST `*github.ErrorResponse`, `*github.RateLimitError`, `*github.AbuseRateLimitError`, shurcooL/githubv4 string-matched errors, and already-classified `*autherr.AuthError`) into the appropriate structured error type.
 - `tryAuthResult` and `authErrString` in `internal/tools/auth_result.go` now call `ClassifyGitHubError` instead of `IsAuthError`, so all tool handlers automatically return structured errors for any of the 8 error types without additional per-handler changes.
 
-
+## [3.0.0] - 2026-05-06
 
 ### Removed
 

--- a/internal/autherr/autherr.go
+++ b/internal/autherr/autherr.go
@@ -1,11 +1,12 @@
-// Package autherr defines structured authentication errors for MCP tool responses.
-// These errors signal to AI agents that the review cycle cannot safely continue
-// and that user action (re-authentication) is required.
+// Package autherr defines structured blocking errors for MCP tool responses.
+// These errors signal to AI agents that an operation cannot safely continue
+// and provide guidance on the appropriate next action (re-authentication,
+// retry after back-off, or stopping the review cycle).
 package autherr
 
 import "errors"
 
-// AuthErrorType identifies the category of authentication error.
+// AuthErrorType identifies the category of blocking error.
 type AuthErrorType string
 
 const (
@@ -15,11 +16,21 @@ const (
 	REAUTH_REQUIRED AuthErrorType = "REAUTH_REQUIRED"
 	// TOKEN_REFRESH_FAILED is returned when a token refresh attempt has failed.
 	TOKEN_REFRESH_FAILED AuthErrorType = "TOKEN_REFRESH_FAILED"
+	// PERMISSION_DENIED is returned when the token lacks sufficient permission (HTTP 403).
+	PERMISSION_DENIED AuthErrorType = "PERMISSION_DENIED"
+	// RATE_LIMITED is returned when GitHub's primary or secondary rate limit is hit.
+	RATE_LIMITED AuthErrorType = "RATE_LIMITED"
+	// NOT_FOUND is returned when the requested resource (repo, PR, thread) does not exist.
+	NOT_FOUND AuthErrorType = "NOT_FOUND"
+	// VALIDATION_ERROR is returned when the request arguments are invalid (HTTP 400/422).
+	VALIDATION_ERROR AuthErrorType = "VALIDATION_ERROR"
+	// TRANSIENT_UPSTREAM_ERROR is returned for temporary errors on the GitHub API side (5xx).
+	TRANSIENT_UPSTREAM_ERROR AuthErrorType = "TRANSIENT_UPSTREAM_ERROR"
 )
 
-// AuthError is a structured blocking error returned when authentication fails.
-// It implements the error interface and serializes to JSON for AI agent consumption.
-// All auth errors are non-retryable and require explicit user action.
+// AuthError is a structured blocking error returned when a GitHub API call fails in a
+// way that prevents the review cycle from continuing safely. It implements the error
+// interface and serializes to JSON for AI agent consumption.
 type AuthError struct {
 	OK                     bool          `json:"ok"`
 	ErrorType              AuthErrorType `json:"error_type"`
@@ -78,6 +89,89 @@ func NewTokenRefreshFailed() *AuthError {
 		SafeToContinue:         false,
 		Message:                "GitHub token refresh failed. Please re-authenticate before continuing.",
 		RecommendedAgentAction: "Stop the review cycle and ask the user to re-authenticate.",
+	}
+}
+
+// NewPermissionDenied returns a PERMISSION_DENIED error for HTTP 403 responses.
+// Use when GitHub rejects the request because the token lacks the required permission.
+func NewPermissionDenied() *AuthError {
+	return &AuthError{
+		OK:                     false,
+		ErrorType:              PERMISSION_DENIED,
+		Severity:               "blocking",
+		Retryable:              false,
+		UserActionRequired:     true,
+		SafeToContinue:         false,
+		Message:                "GitHub permission denied. The token does not have sufficient permission for this operation.",
+		RecommendedAgentAction: "Stop the current operation and ask the user to grant the required GitHub permission.",
+	}
+}
+
+// NewRateLimited returns a RATE_LIMITED error for GitHub primary or secondary rate limits.
+// retryable should be true for primary rate limits (retry after the reset window)
+// and false for secondary / abuse rate limits.
+// safeToContinue should be true only for primary rate limits where a timed retry is feasible.
+func NewRateLimited(retryable, safeToContinue bool) *AuthError {
+	msg := "GitHub secondary rate limit hit. Backing off before retrying is required."
+	action := "Stop the review cycle and wait before retrying. Do not retry immediately."
+	if retryable && safeToContinue {
+		msg = "GitHub rate limit exceeded. Wait until the rate-limit window resets before retrying."
+		action = "Wait until the rate-limit window resets, then retry the operation."
+	}
+	return &AuthError{
+		OK:                     false,
+		ErrorType:              RATE_LIMITED,
+		Severity:               "blocking",
+		Retryable:              retryable,
+		UserActionRequired:     false,
+		SafeToContinue:         safeToContinue,
+		Message:                msg,
+		RecommendedAgentAction: action,
+	}
+}
+
+// NewNotFound returns a NOT_FOUND error when the requested resource does not exist.
+// Use when GitHub responds with HTTP 404 for a repo, PR, or review thread.
+func NewNotFound() *AuthError {
+	return &AuthError{
+		OK:                     false,
+		ErrorType:              NOT_FOUND,
+		Severity:               "blocking",
+		Retryable:              false,
+		UserActionRequired:     false,
+		SafeToContinue:         false,
+		Message:                "The requested GitHub resource was not found. The repo, PR, or thread may not exist or the token may not have read access.",
+		RecommendedAgentAction: "Verify that the owner, repo, and PR number are correct, then stop the review cycle.",
+	}
+}
+
+// NewValidationError returns a VALIDATION_ERROR for invalid request arguments (HTTP 400/422).
+// Use when GitHub rejects the request because the parameters are malformed or out of range.
+func NewValidationError() *AuthError {
+	return &AuthError{
+		OK:                     false,
+		ErrorType:              VALIDATION_ERROR,
+		Severity:               "blocking",
+		Retryable:              false,
+		UserActionRequired:     false,
+		SafeToContinue:         false,
+		Message:                "The request was rejected by GitHub due to invalid arguments.",
+		RecommendedAgentAction: "Check the request parameters for correctness and stop the current operation.",
+	}
+}
+
+// NewTransientUpstreamError returns a TRANSIENT_UPSTREAM_ERROR for temporary GitHub API failures (5xx).
+// Use when GitHub returns a 5xx error that is not directly caused by the request itself.
+func NewTransientUpstreamError() *AuthError {
+	return &AuthError{
+		OK:                     false,
+		ErrorType:              TRANSIENT_UPSTREAM_ERROR,
+		Severity:               "blocking",
+		Retryable:              true,
+		UserActionRequired:     false,
+		SafeToContinue:         false,
+		Message:                "A transient error occurred on the GitHub API side. Retrying after a short delay may succeed.",
+		RecommendedAgentAction: "Wait a moment and retry the operation. If the error persists, stop the review cycle and report to the user.",
 	}
 }
 

--- a/internal/autherr/autherr.go
+++ b/internal/autherr/autherr.go
@@ -112,8 +112,8 @@ func NewPermissionDenied() *AuthError {
 // and false for secondary / abuse rate limits.
 // safeToContinue should be true only for primary rate limits where a timed retry is feasible.
 func NewRateLimited(retryable, safeToContinue bool) *AuthError {
-	msg := "GitHub secondary rate limit hit. Backing off before retrying is required."
-	action := "Stop the review cycle and wait before retrying. Do not retry immediately."
+	msg := "GitHub secondary (abuse) rate limit hit. The token has been temporarily blocked by GitHub. Do not retry automatically."
+	action := "Stop all operations and report to the user. Manual resolution is required; do not retry without user guidance."
 	if retryable && safeToContinue {
 		msg = "GitHub rate limit exceeded. Wait until the rate-limit window resets before retrying."
 		action = "Wait until the rate-limit window resets, then retry the operation."

--- a/internal/autherr/autherr_test.go
+++ b/internal/autherr/autherr_test.go
@@ -16,6 +16,12 @@ func TestAuthErrorImplementsError(t *testing.T) {
 		{"NewAuthRequired", autherr.NewAuthRequired},
 		{"NewReauthRequired", autherr.NewReauthRequired},
 		{"NewTokenRefreshFailed", autherr.NewTokenRefreshFailed},
+		{"NewPermissionDenied", autherr.NewPermissionDenied},
+		{"NewRateLimited(true,true)", func() *autherr.AuthError { return autherr.NewRateLimited(true, true) }},
+		{"NewRateLimited(false,false)", func() *autherr.AuthError { return autherr.NewRateLimited(false, false) }},
+		{"NewNotFound", autherr.NewNotFound},
+		{"NewValidationError", autherr.NewValidationError},
+		{"NewTransientUpstreamError", autherr.NewTransientUpstreamError},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -33,17 +39,26 @@ func TestAuthErrorFields(t *testing.T) {
 		name          string
 		fn            func() *autherr.AuthError
 		wantErrorType autherr.AuthErrorType
+		wantRetryable bool
+		wantUserAction bool
+		wantSafeCont  bool
 	}{
-		{"NewAuthRequired", autherr.NewAuthRequired, autherr.AUTH_REQUIRED},
-		{"NewReauthRequired", autherr.NewReauthRequired, autherr.REAUTH_REQUIRED},
-		{"NewTokenRefreshFailed", autherr.NewTokenRefreshFailed, autherr.TOKEN_REFRESH_FAILED},
+		{"NewAuthRequired", autherr.NewAuthRequired, autherr.AUTH_REQUIRED, false, true, false},
+		{"NewReauthRequired", autherr.NewReauthRequired, autherr.REAUTH_REQUIRED, false, true, false},
+		{"NewTokenRefreshFailed", autherr.NewTokenRefreshFailed, autherr.TOKEN_REFRESH_FAILED, false, true, false},
+		{"NewPermissionDenied", autherr.NewPermissionDenied, autherr.PERMISSION_DENIED, false, true, false},
+		{"NewRateLimited(true,true)", func() *autherr.AuthError { return autherr.NewRateLimited(true, true) }, autherr.RATE_LIMITED, true, false, true},
+		{"NewRateLimited(false,false)", func() *autherr.AuthError { return autherr.NewRateLimited(false, false) }, autherr.RATE_LIMITED, false, false, false},
+		{"NewNotFound", autherr.NewNotFound, autherr.NOT_FOUND, false, false, false},
+		{"NewValidationError", autherr.NewValidationError, autherr.VALIDATION_ERROR, false, false, false},
+		{"NewTransientUpstreamError", autherr.NewTransientUpstreamError, autherr.TRANSIENT_UPSTREAM_ERROR, true, false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ae := tt.fn()
 
 			if ae.OK {
-				t.Error("OK must be false for auth errors")
+				t.Error("OK must be false for all structured errors")
 			}
 			if ae.ErrorType != tt.wantErrorType {
 				t.Errorf("ErrorType = %q, want %q", ae.ErrorType, tt.wantErrorType)
@@ -51,14 +66,14 @@ func TestAuthErrorFields(t *testing.T) {
 			if ae.Severity != "blocking" {
 				t.Errorf("Severity = %q, want %q", ae.Severity, "blocking")
 			}
-			if ae.Retryable {
-				t.Error("Retryable must be false")
+			if ae.Retryable != tt.wantRetryable {
+				t.Errorf("Retryable = %v, want %v", ae.Retryable, tt.wantRetryable)
 			}
-			if !ae.UserActionRequired {
-				t.Error("UserActionRequired must be true")
+			if ae.UserActionRequired != tt.wantUserAction {
+				t.Errorf("UserActionRequired = %v, want %v", ae.UserActionRequired, tt.wantUserAction)
 			}
-			if ae.SafeToContinue {
-				t.Error("SafeToContinue must be false")
+			if ae.SafeToContinue != tt.wantSafeCont {
+				t.Errorf("SafeToContinue = %v, want %v", ae.SafeToContinue, tt.wantSafeCont)
 			}
 			if ae.Message == "" {
 				t.Error("Message must not be empty")
@@ -111,13 +126,19 @@ func TestAsAuthError(t *testing.T) {
 }
 
 func TestAuthErrorTypes(t *testing.T) {
-	if autherr.AUTH_REQUIRED != "AUTH_REQUIRED" {
-		t.Errorf("AUTH_REQUIRED = %q, want %q", autherr.AUTH_REQUIRED, "AUTH_REQUIRED")
+	cases := map[autherr.AuthErrorType]string{
+		autherr.AUTH_REQUIRED:            "AUTH_REQUIRED",
+		autherr.REAUTH_REQUIRED:          "REAUTH_REQUIRED",
+		autherr.TOKEN_REFRESH_FAILED:     "TOKEN_REFRESH_FAILED",
+		autherr.PERMISSION_DENIED:        "PERMISSION_DENIED",
+		autherr.RATE_LIMITED:             "RATE_LIMITED",
+		autherr.NOT_FOUND:                "NOT_FOUND",
+		autherr.VALIDATION_ERROR:         "VALIDATION_ERROR",
+		autherr.TRANSIENT_UPSTREAM_ERROR: "TRANSIENT_UPSTREAM_ERROR",
 	}
-	if autherr.REAUTH_REQUIRED != "REAUTH_REQUIRED" {
-		t.Errorf("REAUTH_REQUIRED = %q, want %q", autherr.REAUTH_REQUIRED, "REAUTH_REQUIRED")
-	}
-	if autherr.TOKEN_REFRESH_FAILED != "TOKEN_REFRESH_FAILED" {
-		t.Errorf("TOKEN_REFRESH_FAILED = %q, want %q", autherr.TOKEN_REFRESH_FAILED, "TOKEN_REFRESH_FAILED")
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("%s = %q, want %q", want, got, want)
+		}
 	}
 }

--- a/internal/github/classify_test.go
+++ b/internal/github/classify_test.go
@@ -1,0 +1,155 @@
+package ghclient_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v85/github"
+
+	"github.com/scottlz0310/copilot-review-mcp/internal/autherr"
+	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
+)
+
+// fakeResponse constructs a minimal http.Response with the given status code for
+// embedding in github.ErrorResponse.
+func fakeResponse(status int) *http.Response {
+	return &http.Response{StatusCode: status}
+}
+
+// ghErrorResponse returns a *github.ErrorResponse with the given HTTP status.
+func ghErrorResponse(status int) error {
+	return &github.ErrorResponse{Response: fakeResponse(status)}
+}
+
+func TestClassifyGitHubError_Nil(t *testing.T) {
+	if got := ghclient.ClassifyGitHubError(nil); got != nil {
+		t.Errorf("ClassifyGitHubError(nil) = %v, want nil", got)
+	}
+}
+
+func TestClassifyGitHubError_AlreadyClassified(t *testing.T) {
+	ae := autherr.NewNotFound()
+	got := ghclient.ClassifyGitHubError(ae)
+	if got == nil {
+		t.Fatal("ClassifyGitHubError(*AuthError) = nil, want non-nil")
+	}
+	if got.ErrorType != autherr.NOT_FOUND {
+		t.Errorf("ErrorType = %q, want %q", got.ErrorType, autherr.NOT_FOUND)
+	}
+}
+
+func TestClassifyGitHubError_WrappedAlreadyClassified(t *testing.T) {
+	ae := autherr.NewPermissionDenied()
+	wrapped := fmt.Errorf("outer: %w", ae)
+	got := ghclient.ClassifyGitHubError(wrapped)
+	if got == nil {
+		t.Fatal("ClassifyGitHubError(wrapped *AuthError) = nil, want non-nil")
+	}
+	if got.ErrorType != autherr.PERMISSION_DENIED {
+		t.Errorf("ErrorType = %q, want %q", got.ErrorType, autherr.PERMISSION_DENIED)
+	}
+}
+
+func TestClassifyGitHubError_RateLimitError(t *testing.T) {
+	rlErr := &github.RateLimitError{
+		Rate:     github.Rate{},
+		Response: fakeResponse(http.StatusForbidden),
+		Message:  "rate limit exceeded",
+	}
+	got := ghclient.ClassifyGitHubError(rlErr)
+	if got == nil {
+		t.Fatal("ClassifyGitHubError(RateLimitError) = nil, want non-nil")
+	}
+	if got.ErrorType != autherr.RATE_LIMITED {
+		t.Errorf("ErrorType = %q, want %q", got.ErrorType, autherr.RATE_LIMITED)
+	}
+	if !got.Retryable {
+		t.Error("Retryable = false, want true for primary rate limit")
+	}
+	if !got.SafeToContinue {
+		t.Error("SafeToContinue = false, want true for primary rate limit")
+	}
+}
+
+func TestClassifyGitHubError_AbuseRateLimitError(t *testing.T) {
+	abuseErr := &github.AbuseRateLimitError{
+		Response: fakeResponse(http.StatusForbidden),
+		Message:  "secondary rate limit",
+	}
+	got := ghclient.ClassifyGitHubError(abuseErr)
+	if got == nil {
+		t.Fatal("ClassifyGitHubError(AbuseRateLimitError) = nil, want non-nil")
+	}
+	if got.ErrorType != autherr.RATE_LIMITED {
+		t.Errorf("ErrorType = %q, want %q", got.ErrorType, autherr.RATE_LIMITED)
+	}
+	if got.Retryable {
+		t.Error("Retryable = true, want false for secondary rate limit")
+	}
+	if got.SafeToContinue {
+		t.Error("SafeToContinue = true, want false for secondary rate limit")
+	}
+}
+
+func TestClassifyGitHubError_HTTPStatusCodes(t *testing.T) {
+	cases := []struct {
+		status    int
+		wantType  autherr.AuthErrorType
+	}{
+		{http.StatusUnauthorized, autherr.REAUTH_REQUIRED},
+		{http.StatusForbidden, autherr.PERMISSION_DENIED},
+		{http.StatusNotFound, autherr.NOT_FOUND},
+		{http.StatusBadRequest, autherr.VALIDATION_ERROR},
+		{http.StatusUnprocessableEntity, autherr.VALIDATION_ERROR},
+		{http.StatusInternalServerError, autherr.TRANSIENT_UPSTREAM_ERROR},
+		{http.StatusBadGateway, autherr.TRANSIENT_UPSTREAM_ERROR},
+		{http.StatusServiceUnavailable, autherr.TRANSIENT_UPSTREAM_ERROR},
+		{http.StatusGatewayTimeout, autherr.TRANSIENT_UPSTREAM_ERROR},
+	}
+	for _, tc := range cases {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			got := ghclient.ClassifyGitHubError(ghErrorResponse(tc.status))
+			if got == nil {
+				t.Fatalf("ClassifyGitHubError(HTTP %d) = nil, want %q", tc.status, tc.wantType)
+			}
+			if got.ErrorType != tc.wantType {
+				t.Errorf("ErrorType = %q, want %q", got.ErrorType, tc.wantType)
+			}
+		})
+	}
+}
+
+func TestClassifyGitHubError_GraphQLStrings(t *testing.T) {
+	cases := []struct {
+		msg      string
+		wantType autherr.AuthErrorType
+	}{
+		{"non-200 OK status code: 401 Unauthorized body: bad creds", autherr.REAUTH_REQUIRED},
+		{"non-200 OK status code: 403 Forbidden body: denied", autherr.PERMISSION_DENIED},
+		{"non-200 OK status code: 404 Not Found body: missing", autherr.NOT_FOUND},
+		{"non-200 OK status code: 422 Unprocessable Entity body: invalid", autherr.VALIDATION_ERROR},
+		{"non-200 OK status code: 500 Internal Server Error body: oops", autherr.TRANSIENT_UPSTREAM_ERROR},
+		{"non-200 OK status code: 502 Bad Gateway body: upstream", autherr.TRANSIENT_UPSTREAM_ERROR},
+		{"non-200 OK status code: 503 Service Unavailable body: down", autherr.TRANSIENT_UPSTREAM_ERROR},
+		{"non-200 OK status code: 504 Gateway Timeout body: slow", autherr.TRANSIENT_UPSTREAM_ERROR},
+	}
+	for _, tc := range cases {
+		t.Run(tc.msg[:30], func(t *testing.T) {
+			got := ghclient.ClassifyGitHubError(fmt.Errorf("%s", tc.msg))
+			if got == nil {
+				t.Fatalf("ClassifyGitHubError(%q) = nil, want %q", tc.msg, tc.wantType)
+			}
+			if got.ErrorType != tc.wantType {
+				t.Errorf("ErrorType = %q, want %q", got.ErrorType, tc.wantType)
+			}
+		})
+	}
+}
+
+func TestClassifyGitHubError_UnknownError(t *testing.T) {
+	got := ghclient.ClassifyGitHubError(fmt.Errorf("something completely different"))
+	if got != nil {
+		t.Errorf("ClassifyGitHubError(unknown) = %v, want nil", got)
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -387,7 +387,7 @@ func ClassifyGitHubError(err error) *autherr.AuthError {
 		return autherr.NewPermissionDenied()
 	case strings.Contains(msg, "404 Not Found"):
 		return autherr.NewNotFound()
-	case strings.Contains(msg, "422 Unprocessable"):
+	case strings.Contains(msg, "422 Unprocessable"), strings.Contains(msg, "400 Bad Request"):
 		return autherr.NewValidationError()
 	case strings.Contains(msg, "500 Internal Server Error"),
 		strings.Contains(msg, "502 Bad Gateway"),

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -14,6 +14,8 @@ import (
 	"github.com/google/go-github/v85/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
+
+	"github.com/scottlz0310/copilot-review-mcp/internal/autherr"
 )
 
 // invalidatingTransport wraps an HTTP transport and calls invalidate(token) when
@@ -323,6 +325,78 @@ func IsAuthError(err error) bool {
 	// shurcooL/githubv4 returns a plain error with the message
 	// "non-200 OK status code: 401 Unauthorized body: ..." for HTTP 401.
 	return strings.Contains(err.Error(), "401 Unauthorized")
+}
+
+// ClassifyGitHubError maps a GitHub API error to a structured *autherr.AuthError.
+// Returns nil when the error is not a recognized GitHub API error (e.g. context.Canceled).
+//
+// Detection order (most-specific first):
+//  1. *autherr.AuthError — already classified upstream; returned as-is.
+//  2. *github.RateLimitError — primary rate limit; retryable, safe to continue after reset.
+//  3. *github.AbuseRateLimitError — secondary / abuse rate limit; not retryable.
+//  4. *github.ErrorResponse — classified by HTTP status code.
+//  5. String-based fallback for shurcooL/githubv4 plain errors.
+func ClassifyGitHubError(err error) *autherr.AuthError {
+	if err == nil {
+		return nil
+	}
+
+	// Already classified.
+	if ae, ok := autherr.AsAuthError(err); ok {
+		return ae
+	}
+
+	// Primary rate limit (go-github wraps 403 + X-RateLimit-Remaining: 0).
+	var rateLimitErr *github.RateLimitError
+	if errors.As(err, &rateLimitErr) {
+		return autherr.NewRateLimited(true, true)
+	}
+
+	// Secondary / abuse rate limit (go-github wraps 403 + abuse message).
+	var abuseErr *github.AbuseRateLimitError
+	if errors.As(err, &abuseErr) {
+		return autherr.NewRateLimited(false, false)
+	}
+
+	// REST API errors with explicit HTTP status codes.
+	var ghErr *github.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Response != nil {
+		switch ghErr.Response.StatusCode {
+		case http.StatusUnauthorized:
+			return autherr.NewReauthRequired()
+		case http.StatusForbidden:
+			return autherr.NewPermissionDenied()
+		case http.StatusNotFound:
+			return autherr.NewNotFound()
+		case http.StatusBadRequest, http.StatusUnprocessableEntity:
+			return autherr.NewValidationError()
+		case http.StatusInternalServerError,
+			http.StatusBadGateway,
+			http.StatusServiceUnavailable,
+			http.StatusGatewayTimeout:
+			return autherr.NewTransientUpstreamError()
+		}
+	}
+
+	// shurcooL/githubv4 plain-error fallbacks (string-based).
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "401 Unauthorized"):
+		return autherr.NewReauthRequired()
+	case strings.Contains(msg, "403 Forbidden"):
+		return autherr.NewPermissionDenied()
+	case strings.Contains(msg, "404 Not Found"):
+		return autherr.NewNotFound()
+	case strings.Contains(msg, "422 Unprocessable"):
+		return autherr.NewValidationError()
+	case strings.Contains(msg, "500 Internal Server Error"),
+		strings.Contains(msg, "502 Bad Gateway"),
+		strings.Contains(msg, "503 Service Unavailable"),
+		strings.Contains(msg, "504 Gateway Timeout"):
+		return autherr.NewTransientUpstreamError()
+	}
+
+	return nil
 }
 
 // prNodeIDQuery fetches the GraphQL node ID for a pull request.

--- a/internal/tools/auth_error_test.go
+++ b/internal/tools/auth_error_test.go
@@ -442,24 +442,47 @@ func TestStatusHandlerTransientUpstreamError(t *testing.T) {
 
 func TestTryAuthResultNewErrorTypes(t *testing.T) {
 	cases := []struct {
-		name     string
-		fn       func() *autherr.AuthError
-		wantType autherr.AuthErrorType
+		name          string
+		err           error
+		wantType      autherr.AuthErrorType
+		wantRetryable bool
 	}{
-		{"PERMISSION_DENIED", autherr.NewPermissionDenied, autherr.PERMISSION_DENIED},
-		{"NOT_FOUND", autherr.NewNotFound, autherr.NOT_FOUND},
-		{"VALIDATION_ERROR", autherr.NewValidationError, autherr.VALIDATION_ERROR},
-		{"TRANSIENT_UPSTREAM_ERROR", autherr.NewTransientUpstreamError, autherr.TRANSIENT_UPSTREAM_ERROR},
+		{"PERMISSION_DENIED", autherr.NewPermissionDenied(), autherr.PERMISSION_DENIED, false},
+		{"NOT_FOUND", autherr.NewNotFound(), autherr.NOT_FOUND, false},
+		{"VALIDATION_ERROR", autherr.NewValidationError(), autherr.VALIDATION_ERROR, false},
+		{"TRANSIENT_UPSTREAM_ERROR", autherr.NewTransientUpstreamError(), autherr.TRANSIENT_UPSTREAM_ERROR, true},
+		{
+			"RATE_LIMITED_primary (via RateLimitError)",
+			&github.RateLimitError{
+				Rate:     github.Rate{},
+				Response: &http.Response{StatusCode: http.StatusForbidden},
+				Message:  "rate limit exceeded",
+			},
+			autherr.RATE_LIMITED,
+			true,
+		},
+		{
+			"RATE_LIMITED_secondary (via AbuseRateLimitError)",
+			&github.AbuseRateLimitError{
+				Response: &http.Response{StatusCode: http.StatusForbidden},
+				Message:  "secondary rate limit",
+			},
+			autherr.RATE_LIMITED,
+			false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, ok := tryAuthResult(tc.fn())
+			result, ok := tryAuthResult(tc.err)
 			if !ok {
 				t.Fatalf("tryAuthResult() ok = false for %s", tc.name)
 			}
 			ae := decodeAuthError(t, result)
 			if ae.ErrorType != tc.wantType {
 				t.Errorf("ErrorType = %q, want %q", ae.ErrorType, tc.wantType)
+			}
+			if ae.Retryable != tc.wantRetryable {
+				t.Errorf("Retryable = %v, want %v", ae.Retryable, tc.wantRetryable)
 			}
 		})
 	}

--- a/internal/tools/auth_error_test.go
+++ b/internal/tools/auth_error_test.go
@@ -323,6 +323,150 @@ func newReplySucceedResolveFail401Server(t *testing.T) *httptest.Server {
 	return srv
 }
 
+// ── helpers for non-401 server responses ──────────────────────────────────────
+
+// newStatusServer returns a test server that responds with the given HTTP status code.
+func newStatusServer(status int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = fmt.Fprintf(w, `{"message":"%s"}`, http.StatusText(status))
+	}))
+}
+
+// makeStatusGitHubClient creates a *ghclient.Client pointing at the given server.
+func makeStatusGitHubClient(srv *httptest.Server) *ghclient.Client {
+	restClient := github.NewClient(srv.Client())
+	base, _ := url.Parse(srv.URL + "/")
+	restClient.BaseURL = base
+	restClient.UploadURL = base
+	gqlClient := githubv4.NewEnterpriseClient(srv.URL, srv.Client())
+	return ghclient.NewWithClients(restClient, gqlClient, 30*time.Second)
+}
+
+// assertBlockingResult checks result is a non-nil error result with the given error type.
+// Unlike assertAuthResult, it does not enforce UserActionRequired = true (some blocking
+// error types like NOT_FOUND and TRANSIENT_UPSTREAM_ERROR have UserActionRequired = false).
+func assertBlockingResult(t *testing.T, result *mcp.CallToolResult, err error, wantType autherr.AuthErrorType) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("handler returned nil result, want structured blocking error")
+	}
+	if !result.IsError {
+		t.Error("result.IsError = false, want true")
+	}
+	ae := decodeAuthError(t, result)
+	if ae.OK {
+		t.Error("AuthError.OK = true, want false")
+	}
+	if ae.ErrorType != wantType {
+		t.Errorf("AuthError.ErrorType = %q, want %q", ae.ErrorType, wantType)
+	}
+	if ae.Severity != "blocking" {
+		t.Errorf("AuthError.Severity = %q, want %q", ae.Severity, "blocking")
+	}
+}
+
+// ── PERMISSION_DENIED (403) ───────────────────────────────────────────────────
+
+func TestStatusHandlerPermissionDenied(t *testing.T) {
+	srv := newStatusServer(http.StatusForbidden)
+	t.Cleanup(srv.Close)
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := statusHandler(staticProvider(makeStatusGitHubClient(srv)), db)
+	result, _, err := handler(context.Background(), nil, GetStatusInput{Owner: "o", Repo: "r", PR: 1})
+	assertBlockingResult(t, result, err, autherr.PERMISSION_DENIED)
+}
+
+// ── NOT_FOUND (404) ───────────────────────────────────────────────────────────
+
+func TestStatusHandlerNotFound(t *testing.T) {
+	srv := newStatusServer(http.StatusNotFound)
+	t.Cleanup(srv.Close)
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := statusHandler(staticProvider(makeStatusGitHubClient(srv)), db)
+	result, _, err := handler(context.Background(), nil, GetStatusInput{Owner: "o", Repo: "r", PR: 1})
+	assertBlockingResult(t, result, err, autherr.NOT_FOUND)
+}
+
+// ── VALIDATION_ERROR (422) ────────────────────────────────────────────────────
+
+func TestStatusHandlerValidationError(t *testing.T) {
+	srv := newStatusServer(http.StatusUnprocessableEntity)
+	t.Cleanup(srv.Close)
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := statusHandler(staticProvider(makeStatusGitHubClient(srv)), db)
+	result, _, err := handler(context.Background(), nil, GetStatusInput{Owner: "o", Repo: "r", PR: 1})
+	assertBlockingResult(t, result, err, autherr.VALIDATION_ERROR)
+}
+
+// ── TRANSIENT_UPSTREAM_ERROR (503) ────────────────────────────────────────────
+
+func TestStatusHandlerTransientUpstreamError(t *testing.T) {
+	srv := newStatusServer(http.StatusServiceUnavailable)
+	t.Cleanup(srv.Close)
+
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	handler := statusHandler(staticProvider(makeStatusGitHubClient(srv)), db)
+	result, _, err := handler(context.Background(), nil, GetStatusInput{Owner: "o", Repo: "r", PR: 1})
+	assertBlockingResult(t, result, err, autherr.TRANSIENT_UPSTREAM_ERROR)
+}
+
+// ── tryAuthResult covers new error types ─────────────────────────────────────
+
+func TestTryAuthResultNewErrorTypes(t *testing.T) {
+	cases := []struct {
+		name     string
+		fn       func() *autherr.AuthError
+		wantType autherr.AuthErrorType
+	}{
+		{"PERMISSION_DENIED", autherr.NewPermissionDenied, autherr.PERMISSION_DENIED},
+		{"NOT_FOUND", autherr.NewNotFound, autherr.NOT_FOUND},
+		{"VALIDATION_ERROR", autherr.NewValidationError, autherr.VALIDATION_ERROR},
+		{"TRANSIENT_UPSTREAM_ERROR", autherr.NewTransientUpstreamError, autherr.TRANSIENT_UPSTREAM_ERROR},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, ok := tryAuthResult(tc.fn())
+			if !ok {
+				t.Fatalf("tryAuthResult() ok = false for %s", tc.name)
+			}
+			ae := decodeAuthError(t, result)
+			if ae.ErrorType != tc.wantType {
+				t.Errorf("ErrorType = %q, want %q", ae.ErrorType, tc.wantType)
+			}
+		})
+	}
+}
+
+// ── TestReplyAndResolveHandlerResolveReauthRequired ───────────────────────────
+
 // TestReplyAndResolveHandlerResolveReauthRequired verifies that when the
 // resolveReviewThread mutation returns 401, the handler sets ResolveError to a
 // canonical REAUTH_REQUIRED string instead of a hard-coded message.

--- a/internal/tools/auth_result.go
+++ b/internal/tools/auth_result.go
@@ -23,8 +23,8 @@ func authErrResult(ae *autherr.AuthError) *mcp.CallToolResult {
 	}
 }
 
-// authErrString returns a canonical "<ErrorType>: <Message>" string for auth
-// errors. It mirrors tryAuthResult's detection logic but returns a plain string
+// authErrString returns a canonical "<ErrorType>: <Message>" string for classified
+// GitHub errors. It mirrors tryAuthResult's detection logic but returns a plain string
 // suitable for embedding in output fields rather than a full MCP result.
 func authErrString(err error) (string, bool) {
 	if err == nil {
@@ -33,19 +33,19 @@ func authErrString(err error) (string, bool) {
 	if ae, ok := autherr.AsAuthError(err); ok {
 		return fmt.Sprintf("%s: %s", ae.ErrorType, ae.Message), true
 	}
-	if ghclient.IsAuthError(err) {
-		ae := autherr.NewReauthRequired()
+	if ae := ghclient.ClassifyGitHubError(err); ae != nil {
 		return fmt.Sprintf("%s: %s", ae.ErrorType, ae.Message), true
 	}
 	return "", false
 }
 
-// tryAuthResult checks whether err represents an authentication failure and, if so,
-// returns a structured *mcp.CallToolResult and true.
+// tryAuthResult checks whether err represents a classified GitHub API failure and,
+// if so, returns a structured *mcp.CallToolResult and true.
 //
 // It handles:
 //   - *autherr.AuthError (e.g. AUTH_REQUIRED from the client provider)
-//   - GitHub HTTP 401 errors detected by ghclient.IsAuthError → REAUTH_REQUIRED
+//   - Any GitHub API error classifiable by ghclient.ClassifyGitHubError
+//     (401→REAUTH_REQUIRED, 403→PERMISSION_DENIED, 404→NOT_FOUND, etc.)
 func tryAuthResult(err error) (*mcp.CallToolResult, bool) {
 	if err == nil {
 		return nil, false
@@ -53,8 +53,8 @@ func tryAuthResult(err error) (*mcp.CallToolResult, bool) {
 	if ae, ok := autherr.AsAuthError(err); ok {
 		return authErrResult(ae), true
 	}
-	if ghclient.IsAuthError(err) {
-		return authErrResult(autherr.NewReauthRequired()), true
+	if ae := ghclient.ClassifyGitHubError(err); ae != nil {
+		return authErrResult(ae), true
 	}
 	return nil, false
 }

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -139,7 +139,7 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration) *StreamableHa
 	// fully initialized, so watchManager is always non-nil.
 	var watchManager *watch.Manager
 	srv := mcp.NewServer(
-		&mcp.Implementation{Name: "copilot-review-mcp", Version: "3.0.0"},
+		&mcp.Implementation{Name: "copilot-review-mcp", Version: "3.1.0"},
 		&mcp.ServerOptions{
 			SchemaCache: schemaCache,
 			SubscribeHandler: func(ctx context.Context, req *mcp.SubscribeRequest) error {


### PR DESCRIPTION
## Summary

Completes [Issue #21](https://github.com/scottlz0310/copilot-review-mcp/issues/21).

PR #22 implemented the first 3 error types (AUTH_REQUIRED, REAUTH_REQUIRED, TOKEN_REFRESH_FAILED). This PR adds the remaining 5 and wires them into the tools layer via a unified classifier.

## Changes

### New error types (internal/autherr)
| Constant | Trigger | retryable | user_action_required | safe_to_continue |
|---|---|---|---|---|
| PERMISSION_DENIED | HTTP 403 (non-rate-limit) | false | true | false |
| RATE_LIMITED (primary) | \*github.RateLimitError\ | true | false | true |
| RATE_LIMITED (secondary) | \*github.AbuseRateLimitError\ | false | false | false |
| NOT_FOUND | HTTP 404 | false | false | false |
| VALIDATION_ERROR | HTTP 400 / 422 | false | false | false |
| TRANSIENT_UPSTREAM_ERROR | HTTP 5xx | true | false | false |

### \ClassifyGitHubError\ (internal/github/client.go)
Single entry point that classifies any GitHub API error into the appropriate \*autherr.AuthError\. Detection order:
1. Already-classified \*autherr.AuthError\ (pass-through)
2. \*github.RateLimitError\ → RATE_LIMITED (primary)
3. \*github.AbuseRateLimitError\ → RATE_LIMITED (secondary)
4. \*github.ErrorResponse\ by status code
5. shurcooL/githubv4 string-matched fallbacks
6. nil (not a known GitHub error)

### Tools layer (internal/tools/auth_result.go)
\	ryAuthResult\ and \uthErrString\ now call \ClassifyGitHubError\ instead of \IsAuthError\. All tool handlers automatically return structured errors for all 8 error types without per-handler changes.

### Tests
- \internal/autherr/autherr_test.go\: extended test tables (all 8 types)
- \internal/github/classify_test.go\: new unit tests for \ClassifyGitHubError\
- \internal/tools/auth_error_test.go\: integration tests for 403/404/422/503 via \statusHandler\

### Version bump
\3.0.0\ → \3.1.0\ (backward-compatible feature addition)

Closes #21