### PR TITLE
chore(release): v3.1.0

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -22,7 +22,11 @@
 - **`ClassifyGitHubError(err error) *autherr.AuthError`** を `internal/github/client.go` に追加。REST `*github.ErrorResponse`、`*github.RateLimitError`、`*github.AbuseRateLimitError`、shurcooL/githubv4 の文字列マッチ、既分類済みの `*autherr.AuthError` を含む任意の GitHub API エラーを適切な構造化エラー型に変換する単一エントリポイント。
 - `internal/tools/auth_result.go` の `tryAuthResult` および `authErrString` が `IsAuthError` の代わりに `ClassifyGitHubError` を呼ぶようになり、8 種類のエラー型すべてに対してハンドラごとの変更なしに構造化エラーを返せるようになった。
 
-## [3.0.0] - 2026-05-06
+### 変更
+
+- skill テンプレート（`docs/skills/`）の MCP サーバーキーを `copilot-review`（旧 `copilot-review-mcp`）と `github`（旧 `github-mcp-server-docker`）に統一。mcp-docker / mcp-gateway のデフォルト設定に合わせた規約変更。usage docs も合わせて更新（#23）。
+
+## [3.0.0]- 2026-05-06
 
 ### 削除
 

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -24,9 +24,9 @@
 
 ### 変更
 
-- skill テンプレート（`docs/skills/`）の MCP サーバーキーを `copilot-review`（旧 `copilot-review-mcp`）と `github`（旧 `github-mcp-server-docker`）に統一。mcp-docker / mcp-gateway のデフォルト設定に合わせた規約変更。usage docs も合わせて更新（#23）。
+- skill テンプレート（`docs/skills/`）の MCP サーバーキーを `copilot-review`（旧 `copilot-review-mcp`）と `github`（旧 `github-mcp-server-docker`）に統一。mcp-docker / mcp-gateway のデフォルト設定に合わせた規約変更（#23）。usage docs（`docs/usage.md`、`docs/usage.ja.md`）も同規約に合わせて更新。
 
-## [3.0.0]- 2026-05-06
+## [3.0.0] - 2026-05-06
 
 ### 削除
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Skill templates (`docs/skills/`) updated to use MCP server key `copilot-review` (was `copilot-review-mcp`) and `github` (was `github-mcp-server-docker`), matching the defaults used in mcp-docker / mcp-gateway setups. Usage docs updated accordingly (#23).
+- Skill templates (`docs/skills/`) updated to use MCP server key `copilot-review` (was `copilot-review-mcp`) and `github` (was `github-mcp-server-docker`), matching the defaults used in mcp-docker / mcp-gateway setups (#23). Usage docs (`docs/usage.md`, `docs/usage.ja.md`) aligned to the same convention.
 
-## [3.0.0]- 2026-05-06
+## [3.0.0] - 2026-05-06
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ClassifyGitHubError(err error) *autherr.AuthError`** in `internal/github/client.go` — a single entry point that classifies any GitHub API error (REST `*github.ErrorResponse`, `*github.RateLimitError`, `*github.AbuseRateLimitError`, shurcooL/githubv4 string-matched errors, and already-classified `*autherr.AuthError`) into the appropriate structured error type.
 - `tryAuthResult` and `authErrString` in `internal/tools/auth_result.go` now call `ClassifyGitHubError` instead of `IsAuthError`, so all tool handlers automatically return structured errors for any of the 8 error types without additional per-handler changes.
 
-## [3.0.0] - 2026-05-06
+### Changed
+
+- Skill templates (`docs/skills/`) updated to use MCP server key `copilot-review` (was `copilot-review-mcp`) and `github` (was `github-mcp-server-docker`), matching the defaults used in mcp-docker / mcp-gateway setups. Usage docs updated accordingly (#23).
+
+## [3.0.0]- 2026-05-06
 
 ### Removed
 

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -139,7 +139,7 @@ mcp-gateway の URL をクライアントに登録する:
 ```json
 {
   "mcpServers": {
-    "copilot-review-mcp": {
+    "copilot-review": {
       "type": "http",
       "url": "https://your-gateway-url/mcp"
     }
@@ -156,7 +156,7 @@ mcp-gateway の URL をクライアントに登録する:
 ```json
 {
   "mcpServers": {
-    "copilot-review-mcp": {
+    "copilot-review": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://your-gateway-url/mcp"]
     }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -139,7 +139,7 @@ Point the client at your mcp-gateway URL:
 ```json
 {
   "mcpServers": {
-    "copilot-review-mcp": {
+    "copilot-review": {
       "type": "http",
       "url": "https://your-gateway-url/mcp"
     }
@@ -156,7 +156,7 @@ Use [mcp-remote](https://github.com/geelen/mcp-remote) as a bridge:
 ```json
 {
   "mcpServers": {
-    "copilot-review-mcp": {
+    "copilot-review": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://your-gateway-url/mcp"]
     }


### PR DESCRIPTION
## v3.1.0 リリース準備

### バージョン判断

`v3.0.0` 以降の変更:
- **feat(autherr)**: 5つの構造化エラー型（`PERMISSION_DENIED`, `RATE_LIMITED`, `NOT_FOUND`, `VALIDATION_ERROR`, `TRANSIENT_UPSTREAM_ERROR`）+ `ClassifyGitHubError` (#22, #24) — 非破壊的追加
- **docs(skills)**: MCP サーバーキー規約を `copilot-review-mcp` → `copilot-review`、`github-mcp-server-docker` → `github` に更新 (#23)
- **chore(deps)**: Go module v1.26.3 更新

セマンティックバージョニング上 **v3.1.0** が適切。

---

### 変更内容

**CHANGELOG.md / CHANGELOG.ja.md**
- v3.1.0 エントリに `### Changed` セクションを追加: PR #23（skill テンプレートの MCP サーバーキー変更）が記載漏れだったため補完

**docs/usage.md / docs/usage.ja.md**
- クライアント設定 JSON の MCP サーバーキーを `copilot-review-mcp` → `copilot-review` に修正
- README.md および skill テンプレート（#23 更新済み）と一致させた

---

### リリース後の作業

マージ後に `v3.1.0` タグをプッシュすると `release.yml` が ghcr.io へ Docker イメージを publish します:

```bash
git tag v3.1.0
git push origin v3.1.0
```