### PR TITLE
feat(watch): Phase B gateway delegated background access — client core (PR-A) (#29)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,6 +9,21 @@
 
 ## [Unreleased]
 
+### 追加
+
+- **Phase B 委譲バックグラウンドアクセス — クライアントコア (PR-A)** — [Issue #29](https://github.com/scottlz0310/copilot-review-mcp/issues/29):
+  - `internal/github/gateway_token_source.go` — gateway の `POST /internal/v1/whoami` を叩く `oauth2.TokenSource` 実装 `gatewayTokenSource`。コンストラクタで loopback ホスト (`127.0.0.1` / `::1` / `localhost`) を検証。`expires_at` を `oauth2.Token.Expiry` に反映するため `oauth2.ReuseTokenSource` で whoami 呼び出しを抑制可能。
+  - Sentinel エラー `ErrGatewaySubjectGone` (404)、`ErrGatewayUnauthorized` (401)、`ErrGatewayLoopbackRequired` (403)、`ErrGatewayUpstreamFailure` (502)、`ErrGatewayBadRequest` (その他 4xx)、`ErrGatewayNonLoopback`。`FailureReasonAuthExpired` / recovery hint へのマッピングは PR-B に延期。
+  - `internal/github/client.go` — 動的トークン用 `NewClientWithTokenSource(ctx, ts, threshold)` を追加（`invalidatingTransport` は付与せず、PR-B で対応）。
+  - `internal/tools/server.go` — `BuilderOptions{GatewayClientFactory}` と `BuildStreamableHandlerWithOptions` を追加。既存 `BuildStreamableHandler(db, threshold)` のシグネチャは維持。
+  - `cmd/server/main.go` — `COPILOT_REVIEW_GATEWAY_INTERNAL_URL` と `COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET` の両方を設定したときのみ opt-in。未設定時は従来通り `oauth2.StaticTokenSource`（動作変更なし）。片方のみ設定された場合は fail-closed で起動を中断。
+  - gateway に送る **subject** は認証済み GitHub login（gateway 仕様に準拠）。
+  - **制約**: PoC のためクライアントと gateway は同一ホスト (loopback) 必須。Docker Compose の複数コンテナ構成は PR-A では非対応。
+
+### 変更
+
+- `watch.Options.ClientFactory` のシグネチャを `func(ctx, token string) ReviewDataFetcher` から `func(ctx, token, login string) ReviewDataFetcher` に拡張。内部呼び出し側のみの修正。
+
 ## [3.1.0] - 2026-05-09
 
 ### 追加

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -23,6 +23,12 @@
 ### 変更
 
 - `watch.Options.ClientFactory` のシグネチャを `func(ctx, token string) ReviewDataFetcher` から `func(ctx, token, login string) ReviewDataFetcher` に拡張。内部呼び出し側のみの修正。
+- **Phase B PR-A レビュー反映 (PR #30 Copilot レビュー)**:
+  - `gatewayTokenSource.Token()` のリクエストコンテキストを設定可能な親 (`GatewayTokenSourceConfig.Context`) と単一の `defaultGatewayTimeout` 定数 (10秒) から派生するよう変更。watch のキャンセル/サーバーシャットダウンが in-flight な whoami 呼び出しに伝播するようになった。
+  - 非 200 応答時にレスポンスボディの一部を破棄してから sentinel エラーを返すことで、`net/http` の keep-alive 接続再利用を可能化。
+  - `ghclient.ValidateGatewayEndpoint(url, secret)` を新設し、`loadConfig` の起動時チェックに組み込み。不正な URL・非 http(s) スキーム・非ループバックホスト・空シークレットは起動時に fail-fast。watch 毎に static トークンへサイレント降格していた挙動を排除。
+  - `buildGatewayClientFactory` で `*http.Client` を 1 度だけ生成し、`GatewayTokenSourceConfig.HTTPClient` 経由で全 watch のトークンソースに共有 (transport / idle 接続プール再利用)。空 login 時のみ到達する static トークンへの runtime フォールバックは `slog.Error` でログ。
+  - `GatewayTokenSourceConfig.HTTPClient` の docstring を修正: トークンソースは subject 毎だが、内部の `*http.Client` / `http.Transport` は並行再利用可能で watch 間で共有すべき。
 
 ## [3.1.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `watch.Options.ClientFactory` signature extended from `func(ctx, token string) ReviewDataFetcher` to `func(ctx, token, login string) ReviewDataFetcher`. Internal-only callers updated.
+- **Phase B PR-A review feedback (PR #30 Copilot review)**:
+  - `gatewayTokenSource.Token()` now derives its request context from a configurable parent (`GatewayTokenSourceConfig.Context`) and a single `defaultGatewayTimeout` constant (10s). Cancelling the watch / shutting down the server now propagates into in-flight whoami calls.
+  - Non-200 responses now drain a bounded portion of the body before returning the mapped sentinel error, letting `net/http` reuse the underlying keep-alive connection.
+  - New `ghclient.ValidateGatewayEndpoint(url, secret)` and `loadConfig` startup check: malformed URL, non-http(s) scheme, non-loopback host, or empty secret now fail-fast at startup instead of silently degrading every watch to static tokens.
+  - `buildGatewayClientFactory` now constructs a single shared `*http.Client` once and passes it via `GatewayTokenSourceConfig.HTTPClient` to every per-watch token source (transport / idle-connection pool reuse). Runtime fallback to static tokens (only reachable on empty GitHub login) is now logged at `slog.Error`.
+  - `GatewayTokenSourceConfig.HTTPClient` documentation clarified: the token source itself must be per-subject, but the underlying `*http.Client` / `http.Transport` is designed for concurrent reuse and should be shared across watches.
 
 ## [3.1.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Phase B delegated background access — client core (PR-A)** for [Issue #29](https://github.com/scottlz0310/copilot-review-mcp/issues/29):
+  - `internal/github/gateway_token_source.go` — `gatewayTokenSource` implements `oauth2.TokenSource` against the gateway's `POST /internal/v1/whoami` endpoint. Validates loopback host (`127.0.0.1` / `::1` / `localhost`) at construction; parses `expires_at` into `oauth2.Token.Expiry` so `oauth2.ReuseTokenSource` only re-resolves near expiry.
+  - Sentinel errors `ErrGatewaySubjectGone` (404), `ErrGatewayUnauthorized` (401), `ErrGatewayLoopbackRequired` (403), `ErrGatewayUpstreamFailure` (502), `ErrGatewayBadRequest` (other 4xx), `ErrGatewayNonLoopback`. Mapping to `FailureReasonAuthExpired` / recovery hints is deferred to PR-B.
+  - `internal/github/client.go` — new `NewClientWithTokenSource(ctx, ts, threshold)` for dynamic-token clients (no `invalidatingTransport`; activation deferred to PR-B).
+  - `internal/tools/server.go` — new `BuilderOptions{GatewayClientFactory}` and `BuildStreamableHandlerWithOptions`. Existing `BuildStreamableHandler(db, threshold)` is unchanged.
+  - `cmd/server/main.go` — opt-in via `COPILOT_REVIEW_GATEWAY_INTERNAL_URL` and `COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET`. When unset, watch goroutines keep using `oauth2.StaticTokenSource` (no behavior change). Fail-closed: setting only one of the two env vars exits at startup.
+  - **Subject** sent to the gateway is the authenticated GitHub login (per gateway docs).
+  - **Limitation**: PoC requires client and gateway on the same host (loopback). Cross-container Docker Compose deployments are not supported in PR-A.
+
+### Changed
+
+- `watch.Options.ClientFactory` signature extended from `func(ctx, token string) ReviewDataFetcher` to `func(ctx, token, login string) ReviewDataFetcher`. Internal-only callers updated.
+
 ## [3.1.0] - 2026-05-09
 
 ### Added

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -109,10 +109,15 @@ func loadConfig() config {
 	// Fail-closed: both env vars must be set together. Configuring only one is
 	// almost always a deployment mistake (e.g., secret leaked but URL forgotten),
 	// so refuse to start rather than silently falling back to static tokens.
+	//
+	// Note: this runs before slog.SetDefault is configured in main(), so we
+	// write directly to stderr instead of via slog. Otherwise startup-time
+	// config failures would be logged with the default slog handler/format
+	// rather than the intended JSON handler + LOG_LEVEL.
 	if (gatewayURL == "") != (gatewaySecret == "") {
-		slog.Error("phase B gateway config is incomplete: set both COPILOT_REVIEW_GATEWAY_INTERNAL_URL and COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET, or neither",
-			"url_set", gatewayURL != "",
-			"secret_set", gatewaySecret != "")
+		fmt.Fprintf(os.Stderr,
+			"copilot-review-mcp: phase B gateway config is incomplete: set both COPILOT_REVIEW_GATEWAY_INTERNAL_URL and COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET, or neither (url_set=%t secret_set=%t)\n",
+			gatewayURL != "", gatewaySecret != "")
 		os.Exit(1)
 	}
 	// When both are set, validate URL/secret at startup so misconfiguration
@@ -120,7 +125,7 @@ func loadConfig() config {
 	// every watch to static tokens at runtime.
 	if gatewayURL != "" {
 		if err := ghclient.ValidateGatewayEndpoint(gatewayURL, gatewaySecret); err != nil {
-			slog.Error("phase B gateway config rejected at startup", "err", err)
+			fmt.Fprintf(os.Stderr, "copilot-review-mcp: phase B gateway config rejected at startup: %v\n", err)
 			os.Exit(1)
 		}
 	}
@@ -153,7 +158,7 @@ func loadConfig() config {
 // can still make progress; this preserves availability but is loud enough
 // for ops to detect that Phase B is not actually engaged.
 func buildGatewayClientFactory(endpointURL, secret string, threshold time.Duration) func(ctx context.Context, token, login string) watch.ReviewDataFetcher {
-	sharedHTTP := &http.Client{Timeout: 10 * time.Second}
+	sharedHTTP := &http.Client{Timeout: ghclient.DefaultGatewayTimeout}
 	return func(ctx context.Context, token, login string) watch.ReviewDataFetcher {
 		ts, err := ghclient.NewGatewayTokenSource(ghclient.GatewayTokenSourceConfig{
 			EndpointURL: endpointURL,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -115,6 +115,15 @@ func loadConfig() config {
 			"secret_set", gatewaySecret != "")
 		os.Exit(1)
 	}
+	// When both are set, validate URL/secret at startup so misconfiguration
+	// (bad scheme, non-loopback host) fails fast instead of silently degrading
+	// every watch to static tokens at runtime.
+	if gatewayURL != "" {
+		if err := ghclient.ValidateGatewayEndpoint(gatewayURL, gatewaySecret); err != nil {
+			slog.Error("phase B gateway config rejected at startup", "err", err)
+			os.Exit(1)
+		}
+	}
 	return config{
 		port:                   getEnv("MCP_PORT", "8083"),
 		bindAddr:               getEnv("BIND_ADDR", "127.0.0.1"),
@@ -130,19 +139,31 @@ func loadConfig() config {
 // access token for the authenticated GitHub login from the gateway's
 // /internal/v1/whoami endpoint. The returned source is wrapped in
 // oauth2.ReuseTokenSource per watch so whoami is only hit when the cached
-// token is near expiry. If gateway token-source construction fails (e.g.,
-// empty login), the factory falls back to a static-token client so the watch
-// can still make progress; PR-B will replace this with structured error
-// mapping (#29).
+// token is near expiry.
+//
+// A single *http.Client is constructed once and shared across every watch's
+// token source. The underlying http.Transport is safe for concurrent reuse
+// and sharing it avoids allocating a fresh transport (and its idle-connection
+// pool) per watch.
+//
+// Endpoint URL and shared secret are validated at startup in loadConfig, so
+// the only failure remaining at watch creation is an empty GitHub login
+// (which would indicate a session-binding bug, not a config error). In that
+// case we log at Error level and fall back to the static token so the watch
+// can still make progress; this preserves availability but is loud enough
+// for ops to detect that Phase B is not actually engaged.
 func buildGatewayClientFactory(endpointURL, secret string, threshold time.Duration) func(ctx context.Context, token, login string) watch.ReviewDataFetcher {
+	sharedHTTP := &http.Client{Timeout: 10 * time.Second}
 	return func(ctx context.Context, token, login string) watch.ReviewDataFetcher {
 		ts, err := ghclient.NewGatewayTokenSource(ghclient.GatewayTokenSourceConfig{
 			EndpointURL: endpointURL,
 			Secret:      secret,
 			Subject:     login,
+			HTTPClient:  sharedHTTP,
+			Context:     ctx,
 		})
 		if err != nil {
-			slog.Warn("gateway token source unavailable; using static token for this watch",
+			slog.Error("gateway token source unavailable; phase B disabled for this watch, falling back to static token",
 				"login", login, "err", err)
 			return ghclient.NewClient(ctx, token, threshold, nil)
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -11,9 +12,13 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/oauth2"
+
+	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
 	"github.com/scottlz0310/copilot-review-mcp/internal/middleware"
 	"github.com/scottlz0310/copilot-review-mcp/internal/store"
 	"github.com/scottlz0310/copilot-review-mcp/internal/tools"
+	"github.com/scottlz0310/copilot-review-mcp/internal/watch"
 )
 
 func main() {
@@ -57,7 +62,13 @@ func main() {
 
 	// MCP endpoints (auth required) — Streamable HTTP transport (stateful, shared server)
 	threshold := time.Duration(cfg.inProgressThresholdSec) * time.Second
-	mcpHandler := tools.BuildStreamableHandler(db, threshold)
+	builderOpts := tools.BuilderOptions{}
+	if cfg.gatewayInternalURL != "" {
+		slog.Info("phase B gateway delegated background access enabled",
+			"endpoint", cfg.gatewayInternalURL)
+		builderOpts.GatewayClientFactory = buildGatewayClientFactory(cfg.gatewayInternalURL, cfg.gatewayInternalSecret, threshold)
+	}
+	mcpHandler := tools.BuildStreamableHandlerWithOptions(db, threshold, builderOpts)
 	defer mcpHandler.Close()
 	mux.Handle("/mcp", authMiddleware(mcpHandler))
 	mux.Handle("/mcp/", authMiddleware(mcpHandler))
@@ -88,15 +99,54 @@ type config struct {
 	logLevel               string
 	sqlitePath             string
 	inProgressThresholdSec int
+	gatewayInternalURL     string
+	gatewayInternalSecret  string
 }
 
 func loadConfig() config {
+	gatewayURL := strings.TrimSpace(os.Getenv("COPILOT_REVIEW_GATEWAY_INTERNAL_URL"))
+	gatewaySecret := strings.TrimSpace(os.Getenv("COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET"))
+	// Fail-closed: both env vars must be set together. Configuring only one is
+	// almost always a deployment mistake (e.g., secret leaked but URL forgotten),
+	// so refuse to start rather than silently falling back to static tokens.
+	if (gatewayURL == "") != (gatewaySecret == "") {
+		slog.Error("phase B gateway config is incomplete: set both COPILOT_REVIEW_GATEWAY_INTERNAL_URL and COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET, or neither",
+			"url_set", gatewayURL != "",
+			"secret_set", gatewaySecret != "")
+		os.Exit(1)
+	}
 	return config{
 		port:                   getEnv("MCP_PORT", "8083"),
 		bindAddr:               getEnv("BIND_ADDR", "127.0.0.1"),
 		logLevel:               getEnv("LOG_LEVEL", "info"),
 		sqlitePath:             getEnv("SQLITE_PATH", "/data/copilot-review.db"),
 		inProgressThresholdSec: getEnvInt("IN_PROGRESS_THRESHOLD_SEC", 30),
+		gatewayInternalURL:     gatewayURL,
+		gatewayInternalSecret:  gatewaySecret,
+	}
+}
+
+// buildGatewayClientFactory returns a watch ClientFactory that resolves the
+// access token for the authenticated GitHub login from the gateway's
+// /internal/v1/whoami endpoint. The returned source is wrapped in
+// oauth2.ReuseTokenSource per watch so whoami is only hit when the cached
+// token is near expiry. If gateway token-source construction fails (e.g.,
+// empty login), the factory falls back to a static-token client so the watch
+// can still make progress; PR-B will replace this with structured error
+// mapping (#29).
+func buildGatewayClientFactory(endpointURL, secret string, threshold time.Duration) func(ctx context.Context, token, login string) watch.ReviewDataFetcher {
+	return func(ctx context.Context, token, login string) watch.ReviewDataFetcher {
+		ts, err := ghclient.NewGatewayTokenSource(ghclient.GatewayTokenSourceConfig{
+			EndpointURL: endpointURL,
+			Secret:      secret,
+			Subject:     login,
+		})
+		if err != nil {
+			slog.Warn("gateway token source unavailable; using static token for this watch",
+				"login", login, "err", err)
+			return ghclient.NewClient(ctx, token, threshold, nil)
+		}
+		return ghclient.NewClientWithTokenSource(ctx, oauth2.ReuseTokenSource(nil, ts), threshold)
 	}
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -132,6 +132,23 @@ func NewClient(ctx context.Context, token string, threshold time.Duration, inval
 	}
 }
 
+// NewClientWithTokenSource creates a Client backed by an arbitrary
+// oauth2.TokenSource. Use this with a gatewayTokenSource (wrapped in
+// oauth2.ReuseTokenSource) so long-lived watch goroutines pick up tokens
+// rotated by the gateway transparently.
+//
+// invalidatingTransport is not attached here because the "current" token is
+// dynamic — invalidation on 401 is deferred to PR-B per
+// scottlz0310/copilot-review-mcp#29.
+func NewClientWithTokenSource(ctx context.Context, ts oauth2.TokenSource, threshold time.Duration) *Client {
+	httpClient := oauth2.NewClient(ctx, ts)
+	return &Client{
+		gh:        github.NewClient(httpClient),
+		v4:        githubv4.NewClient(httpClient),
+		threshold: threshold,
+	}
+}
+
 // NewWithClients creates a Client from pre-built REST and GraphQL API clients.
 // Intended for tests that need to inject mock HTTP servers in place of api.github.com.
 func NewWithClients(gh *github.Client, v4 *githubv4.Client, threshold time.Duration) *Client {

--- a/internal/github/gateway_token_source.go
+++ b/internal/github/gateway_token_source.go
@@ -1,0 +1,224 @@
+package ghclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// Gateway delegated background access (Phase B) sentinel errors.
+//
+// PR-A purposefully keeps these as opaque sentinels so callers can use
+// errors.Is. The mapping to higher-level failure reasons (e.g.
+// FailureReasonAuthExpired) and recovery hints is deferred to PR-B per
+// the design in scottlz0310/copilot-review-mcp#29.
+var (
+	// ErrGatewaySubjectGone indicates the gateway no longer has a cached
+	// token record for the subject (HTTP 404). This is permanent until the
+	// user issues a fresh client request that re-seeds the gateway cache.
+	ErrGatewaySubjectGone = errors.New("gateway: subject not found (404)")
+
+	// ErrGatewayUnauthorized indicates the shared secret was rejected by
+	// the gateway (HTTP 401). This is a configuration error on this side.
+	ErrGatewayUnauthorized = errors.New("gateway: invalid shared secret (401)")
+
+	// ErrGatewayLoopbackRequired indicates the gateway rejected the request
+	// because it did not originate from a loopback address (HTTP 403). This
+	// generally means client and gateway are not co-located on the same host.
+	ErrGatewayLoopbackRequired = errors.New("gateway: loopback required (403)")
+
+	// ErrGatewayUpstreamFailure indicates the gateway tried to rotate the
+	// token but the GitHub OAuth provider failed (HTTP 502). Retryable.
+	ErrGatewayUpstreamFailure = errors.New("gateway: upstream rotation failure (502)")
+
+	// ErrGatewayBadRequest covers 4xx responses that are neither 401/403/404.
+	ErrGatewayBadRequest = errors.New("gateway: bad request (4xx)")
+)
+
+// ErrGatewayNonLoopback is returned by NewGatewayTokenSource when the
+// configured URL does not resolve to a loopback host. Co-location with the
+// gateway on the same host is a Phase B PoC requirement; cross-host delegated
+// access is future work (see docs/spike-72-delegated-background-access.md
+// "Future work").
+var ErrGatewayNonLoopback = errors.New("gateway: endpoint URL must be loopback (127.0.0.1 / ::1 / localhost)")
+
+// GatewayTokenSourceConfig configures a gatewayTokenSource.
+type GatewayTokenSourceConfig struct {
+	// EndpointURL is the full URL of the gateway's whoami endpoint,
+	// e.g. "http://127.0.0.1:8081/internal/v1/whoami". Must be loopback.
+	EndpointURL string
+
+	// Secret is the shared bearer secret (MCP_GATEWAY_INTERNAL_SECRET on
+	// the gateway side). Required to be non-empty.
+	Secret string
+
+	// Subject identifies which cached token entry the gateway should
+	// return. In this repo, Subject is the GitHub login (gateway's docs
+	// explicitly document subject as the GitHub login).
+	Subject string
+
+	// HTTPClient is the underlying transport. Optional; if nil a fresh
+	// client with a 5s timeout is used. Callers should not enable
+	// connection re-use across goroutines for different subjects.
+	HTTPClient *http.Client
+}
+
+type whoamiResponse struct {
+	AccessToken string   `json:"access_token"`
+	TokenType   string   `json:"token_type"`
+	ExpiresAt   string   `json:"expires_at,omitempty"`
+	Scopes      []string `json:"scopes,omitempty"`
+}
+
+// gatewayTokenSource is an oauth2.TokenSource that resolves the current
+// access token for a fixed subject via the gateway's internal delegated
+// background access API (Phase B PoC).
+//
+// Each call to Token() issues a POST /internal/v1/whoami request and returns
+// the fresh access_token along with its expires_at parsed into oauth2.Token.Expiry.
+// Wrap this source in oauth2.ReuseTokenSource(nil, ts) so that whoami is only
+// hit when the cached token is near expiry.
+//
+// Limitation: client and gateway must be co-located on the same host because
+// the gateway's listener binds to 127.0.0.1 and rejects non-loopback peers.
+// In particular, Docker Compose deployments that place client and gateway in
+// separate containers cannot use this PoC as-is — see
+// docs/spike-72-delegated-background-access.md "Trust boundary" / "Future work".
+type gatewayTokenSource struct {
+	endpoint string
+	secret   string
+	subject  string
+	httpc    *http.Client
+}
+
+// NewGatewayTokenSource constructs a gatewayTokenSource after validating the
+// loopback constraint and required fields. Returns an error rather than a
+// silent no-op so misconfigurations surface at startup.
+func NewGatewayTokenSource(cfg GatewayTokenSourceConfig) (oauth2.TokenSource, error) {
+	if strings.TrimSpace(cfg.EndpointURL) == "" {
+		return nil, errors.New("gateway: endpoint URL is required")
+	}
+	if strings.TrimSpace(cfg.Secret) == "" {
+		return nil, errors.New("gateway: shared secret is required")
+	}
+	if strings.TrimSpace(cfg.Subject) == "" {
+		return nil, errors.New("gateway: subject is required")
+	}
+	u, err := url.Parse(cfg.EndpointURL)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: invalid endpoint URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("gateway: endpoint URL scheme must be http or https, got %q", u.Scheme)
+	}
+	host := u.Hostname()
+	if !isLoopbackHost(host) {
+		return nil, fmt.Errorf("%w: got host %q", ErrGatewayNonLoopback, host)
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = &http.Client{Timeout: 5 * time.Second}
+	}
+	return &gatewayTokenSource{
+		endpoint: cfg.EndpointURL,
+		secret:   cfg.Secret,
+		subject:  cfg.Subject,
+		httpc:    hc,
+	}, nil
+}
+
+// isLoopbackHost reports whether host refers to the local machine. Accepts
+// the literal hostnames "localhost", "127.0.0.1", "::1" (and bracketed form
+// from URLs already stripped by url.Hostname), as well as any IP that
+// net.ParseIP confirms as loopback.
+func isLoopbackHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// Token fetches the current access token from the gateway whoami endpoint.
+// Implements oauth2.TokenSource.
+func (g *gatewayTokenSource) Token() (*oauth2.Token, error) {
+	body, err := json.Marshal(map[string]string{"subject": g.subject})
+	if err != nil {
+		return nil, fmt.Errorf("gateway: marshal whoami body: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("gateway: build whoami request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+g.secret)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := g.httpc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: whoami request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// fallthrough below
+	case http.StatusUnauthorized:
+		return nil, ErrGatewayUnauthorized
+	case http.StatusForbidden:
+		return nil, ErrGatewayLoopbackRequired
+	case http.StatusNotFound:
+		return nil, ErrGatewaySubjectGone
+	case http.StatusBadGateway:
+		return nil, ErrGatewayUpstreamFailure
+	default:
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+			return nil, fmt.Errorf("%w: status=%d", ErrGatewayBadRequest, resp.StatusCode)
+		}
+		return nil, fmt.Errorf("gateway: unexpected status %d", resp.StatusCode)
+	}
+
+	// Cap response body to a defensive size; whoami responses are tiny.
+	rbody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return nil, fmt.Errorf("gateway: read whoami body: %w", err)
+	}
+	var r whoamiResponse
+	if err := json.Unmarshal(rbody, &r); err != nil {
+		return nil, fmt.Errorf("gateway: decode whoami body: %w", err)
+	}
+	if r.AccessToken == "" {
+		return nil, errors.New("gateway: whoami response missing access_token")
+	}
+	tok := &oauth2.Token{
+		AccessToken: r.AccessToken,
+		TokenType:   r.TokenType,
+	}
+	if r.ExpiresAt != "" {
+		// Parse RFC3339; on parse failure leave Expiry zero (treated as
+		// "no expiry known"), which causes ReuseTokenSource to call Token
+		// only on first use and on explicit invalidation. Logging is left
+		// to the caller because this package must remain log-agnostic.
+		if t, perr := time.Parse(time.RFC3339, r.ExpiresAt); perr == nil {
+			tok.Expiry = t
+		}
+	}
+	return tok, nil
+}

--- a/internal/github/gateway_token_source.go
+++ b/internal/github/gateway_token_source.go
@@ -52,11 +52,27 @@ var (
 // "Future work").
 var ErrGatewayNonLoopback = errors.New("gateway: endpoint URL must be loopback (127.0.0.1 / ::1 / localhost)")
 
-// defaultGatewayTimeout bounds a single whoami round-trip. The same value is
+// ErrGatewayInvalidPath is returned when the gateway endpoint URL is missing
+// the expected whoami path. The README/changelog document EndpointURL as the
+// full whoami endpoint (e.g. http://127.0.0.1:8081/internal/v1/whoami), so a
+// URL that only carries the host:port would silently fail at runtime with a
+// confusing 404. This error makes that misconfiguration fail at startup.
+var ErrGatewayInvalidPath = errors.New(`gateway: endpoint URL must end with "/whoami" (e.g. http://127.0.0.1:8081/internal/v1/whoami)`)
+
+// DefaultGatewayTimeout bounds a single whoami round-trip. The same value is
 // used for both the default http.Client.Timeout (when caller does not supply
 // one) and the per-call context deadline derived from Context, so request-
 // level cancellation and transport-level timeout agree.
-const defaultGatewayTimeout = 10 * time.Second
+//
+// Exported so callers that construct their own *http.Client (e.g.
+// cmd/server/main.go's buildGatewayClientFactory) can share this single
+// source of truth and avoid the context-deadline vs transport-timeout drift
+// previously fixed in this package.
+const DefaultGatewayTimeout = 10 * time.Second
+
+// defaultGatewayTimeout is kept as an internal alias so the existing call
+// sites in this file continue to compile unchanged.
+const defaultGatewayTimeout = DefaultGatewayTimeout
 
 // GatewayTokenSourceConfig configures a gatewayTokenSource.
 type GatewayTokenSourceConfig struct {
@@ -144,6 +160,9 @@ func ValidateGatewayEndpoint(endpointURL, secret string) error {
 	if !isLoopbackHost(u.Hostname()) {
 		return fmt.Errorf("%w: got host %q", ErrGatewayNonLoopback, u.Hostname())
 	}
+	if !strings.HasSuffix(u.Path, "/whoami") {
+		return fmt.Errorf("%w: got path %q", ErrGatewayInvalidPath, u.Path)
+	}
 	return nil
 }
 
@@ -170,6 +189,9 @@ func NewGatewayTokenSource(cfg GatewayTokenSourceConfig) (oauth2.TokenSource, er
 	host := u.Hostname()
 	if !isLoopbackHost(host) {
 		return nil, fmt.Errorf("%w: got host %q", ErrGatewayNonLoopback, host)
+	}
+	if !strings.HasSuffix(u.Path, "/whoami") {
+		return nil, fmt.Errorf("%w: got path %q", ErrGatewayInvalidPath, u.Path)
 	}
 	hc := cfg.HTTPClient
 	if hc == nil {

--- a/internal/github/gateway_token_source.go
+++ b/internal/github/gateway_token_source.go
@@ -59,6 +59,16 @@ var ErrGatewayNonLoopback = errors.New("gateway: endpoint URL must be loopback (
 // confusing 404. This error makes that misconfiguration fail at startup.
 var ErrGatewayInvalidPath = errors.New(`gateway: endpoint URL must end with "/whoami" (e.g. http://127.0.0.1:8081/internal/v1/whoami)`)
 
+// ErrGatewayInvalidExpiry is returned when the gateway whoami response is
+// missing expires_at or contains a value that cannot be parsed as RFC3339.
+//
+// Without an Expiry, oauth2.ReuseTokenSource treats the token as never
+// expiring and caches it indefinitely, so the watch would never re-fetch
+// from the gateway even after the real underlying token expires. We fail
+// closed instead, forcing the caller to either fix the gateway response
+// or recover with a fresh whoami call on the next attempt.
+var ErrGatewayInvalidExpiry = errors.New(`gateway: whoami response missing or invalid expires_at`)
+
 // DefaultGatewayTimeout bounds a single whoami round-trip. The same value is
 // used for both the default http.Client.Timeout (when caller does not supply
 // one) and the per-call context deadline derived from Context, so request-
@@ -296,14 +306,17 @@ func (g *gatewayTokenSource) Token() (*oauth2.Token, error) {
 		AccessToken: r.AccessToken,
 		TokenType:   r.TokenType,
 	}
-	if r.ExpiresAt != "" {
-		// Parse RFC3339; on parse failure leave Expiry zero (treated as
-		// "no expiry known"), which causes ReuseTokenSource to call Token
-		// only on first use and on explicit invalidation. Logging is left
-		// to the caller because this package must remain log-agnostic.
-		if t, perr := time.Parse(time.RFC3339, r.ExpiresAt); perr == nil {
-			tok.Expiry = t
-		}
+	// expires_at is required. A zero Expiry combined with
+	// oauth2.ReuseTokenSource means the token is treated as never
+	// expiring, which would silently disable refresh after the real
+	// gateway-side token expires. Fail closed.
+	if r.ExpiresAt == "" {
+		return nil, ErrGatewayInvalidExpiry
 	}
+	t, perr := time.Parse(time.RFC3339, r.ExpiresAt)
+	if perr != nil {
+		return nil, fmt.Errorf("%w: %v", ErrGatewayInvalidExpiry, perr)
+	}
+	tok.Expiry = t
 	return tok, nil
 }

--- a/internal/github/gateway_token_source.go
+++ b/internal/github/gateway_token_source.go
@@ -52,6 +52,12 @@ var (
 // "Future work").
 var ErrGatewayNonLoopback = errors.New("gateway: endpoint URL must be loopback (127.0.0.1 / ::1 / localhost)")
 
+// defaultGatewayTimeout bounds a single whoami round-trip. The same value is
+// used for both the default http.Client.Timeout (when caller does not supply
+// one) and the per-call context deadline derived from Context, so request-
+// level cancellation and transport-level timeout agree.
+const defaultGatewayTimeout = 10 * time.Second
+
 // GatewayTokenSourceConfig configures a gatewayTokenSource.
 type GatewayTokenSourceConfig struct {
 	// EndpointURL is the full URL of the gateway's whoami endpoint,
@@ -68,9 +74,20 @@ type GatewayTokenSourceConfig struct {
 	Subject string
 
 	// HTTPClient is the underlying transport. Optional; if nil a fresh
-	// client with a 5s timeout is used. Callers should not enable
-	// connection re-use across goroutines for different subjects.
+	// client with defaultGatewayTimeout is used. The token source itself
+	// must be constructed per-subject (each watch has its own subject),
+	// but the underlying *http.Client / http.Transport are designed for
+	// concurrent reuse and SHOULD be shared across token sources to
+	// avoid leaking idle connections.
 	HTTPClient *http.Client
+
+	// Context is the long-lived parent context (e.g., the watch
+	// goroutine's context). Token() derives a per-request context with
+	// defaultGatewayTimeout from this parent, so cancelling the parent
+	// (watch stop / server shutdown) also cancels any in-flight whoami
+	// call. Optional; defaults to context.Background() which yields the
+	// previous "timeout-only" behavior.
+	Context context.Context
 }
 
 type whoamiResponse struct {
@@ -99,6 +116,35 @@ type gatewayTokenSource struct {
 	secret   string
 	subject  string
 	httpc    *http.Client
+	parent   context.Context
+}
+
+// ValidateGatewayEndpoint performs subject-independent validation of the
+// gateway endpoint URL and shared secret. It is intended for startup-time
+// fail-fast checks (e.g., in cmd/server/main.go) where the GitHub login
+// (Subject) is not yet known but the deployment-level configuration must be
+// rejected if it is malformed.
+//
+// Returns the same error sentinels as NewGatewayTokenSource for URL/scheme/
+// loopback violations (ErrGatewayNonLoopback for non-loopback hosts).
+func ValidateGatewayEndpoint(endpointURL, secret string) error {
+	if strings.TrimSpace(endpointURL) == "" {
+		return errors.New("gateway: endpoint URL is required")
+	}
+	if strings.TrimSpace(secret) == "" {
+		return errors.New("gateway: shared secret is required")
+	}
+	u, err := url.Parse(endpointURL)
+	if err != nil {
+		return fmt.Errorf("gateway: invalid endpoint URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("gateway: endpoint URL scheme must be http or https, got %q", u.Scheme)
+	}
+	if !isLoopbackHost(u.Hostname()) {
+		return fmt.Errorf("%w: got host %q", ErrGatewayNonLoopback, u.Hostname())
+	}
+	return nil
 }
 
 // NewGatewayTokenSource constructs a gatewayTokenSource after validating the
@@ -127,13 +173,18 @@ func NewGatewayTokenSource(cfg GatewayTokenSourceConfig) (oauth2.TokenSource, er
 	}
 	hc := cfg.HTTPClient
 	if hc == nil {
-		hc = &http.Client{Timeout: 5 * time.Second}
+		hc = &http.Client{Timeout: defaultGatewayTimeout}
+	}
+	parent := cfg.Context
+	if parent == nil {
+		parent = context.Background()
 	}
 	return &gatewayTokenSource{
 		endpoint: cfg.EndpointURL,
 		secret:   cfg.Secret,
 		subject:  cfg.Subject,
 		httpc:    hc,
+		parent:   parent,
 	}, nil
 }
 
@@ -156,12 +207,16 @@ func isLoopbackHost(host string) bool {
 
 // Token fetches the current access token from the gateway whoami endpoint.
 // Implements oauth2.TokenSource.
+//
+// The request context is derived from the configured parent context with
+// defaultGatewayTimeout, so cancellation of the watch (or server shutdown)
+// propagates into the in-flight whoami call.
 func (g *gatewayTokenSource) Token() (*oauth2.Token, error) {
 	body, err := json.Marshal(map[string]string{"subject": g.subject})
 	if err != nil {
 		return nil, fmt.Errorf("gateway: marshal whoami body: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(g.parent, defaultGatewayTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.endpoint, bytes.NewReader(body))
 	if err != nil {
@@ -176,6 +231,14 @@ func (g *gatewayTokenSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("gateway: whoami request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		// Drain a bounded portion of the body so net/http can reuse the
+		// underlying connection on keep-alive. Errors here are ignored;
+		// connection reuse is best-effort, and we still want to surface
+		// the original status-derived error to the caller below.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	}
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/internal/github/gateway_token_source_test.go
+++ b/internal/github/gateway_token_source_test.go
@@ -50,6 +50,81 @@ func TestNewGatewayTokenSource_NonLoopbackError(t *testing.T) {
 	}
 }
 
+// TestNewGatewayTokenSource_InvalidPathError verifies that a loopback URL
+// missing the /whoami suffix is rejected at construction so the misconfiguration
+// surfaces at startup rather than at the first watch's first whoami round-trip
+// (where it would manifest as a confusing 404 / ErrGatewaySubjectGone).
+func TestNewGatewayTokenSource_InvalidPathError(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"http://127.0.0.1:8081",
+		"http://127.0.0.1:8081/",
+		"http://127.0.0.1:8081/internal/v1",
+		"http://127.0.0.1:8081/health",
+	}
+	for _, u := range cases {
+		u := u
+		t.Run(u, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
+				EndpointURL: u,
+				Secret:      "s",
+				Subject:     "alice",
+			})
+			if !errors.Is(err, ErrGatewayInvalidPath) {
+				t.Fatalf("expected ErrGatewayInvalidPath, got %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateGatewayEndpoint covers the subject-independent startup-time
+// validation used by cmd/server/main.go before any watch exists.
+func TestValidateGatewayEndpoint(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		url     string
+		secret  string
+		wantErr error
+	}{
+		{name: "ok", url: "http://127.0.0.1:8081/internal/v1/whoami", secret: "s", wantErr: nil},
+		{name: "ok localhost", url: "http://localhost:8081/internal/v1/whoami", secret: "s", wantErr: nil},
+		{name: "missing url", url: "", secret: "s", wantErr: errors.New("required")},
+		{name: "missing secret", url: "http://127.0.0.1:8081/internal/v1/whoami", secret: "", wantErr: errors.New("required")},
+		{name: "bad scheme", url: "ftp://127.0.0.1/internal/v1/whoami", secret: "s", wantErr: errors.New("scheme")},
+		{name: "non-loopback", url: "http://example.com/internal/v1/whoami", secret: "s", wantErr: ErrGatewayNonLoopback},
+		{name: "no path", url: "http://127.0.0.1:8081", secret: "s", wantErr: ErrGatewayInvalidPath},
+		{name: "wrong path", url: "http://127.0.0.1:8081/health", secret: "s", wantErr: ErrGatewayInvalidPath},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateGatewayEndpoint(tc.url, tc.secret)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			// Sentinel errors use errors.Is; ad-hoc errors are matched on substring.
+			if errors.Is(tc.wantErr, ErrGatewayNonLoopback) || errors.Is(tc.wantErr, ErrGatewayInvalidPath) {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected sentinel %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if !strings.Contains(err.Error(), tc.wantErr.Error()) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr.Error(), err)
+			}
+		})
+	}
+}
+
 func TestNewGatewayTokenSource_AcceptsLoopbackVariants(t *testing.T) {
 	t.Parallel()
 	for _, host := range []string{"127.0.0.1", "[::1]", "localhost"} {
@@ -175,12 +250,15 @@ func TestGatewayTokenSource_MissingAccessToken(t *testing.T) {
 	t.Parallel()
 	srv := fakeWhoamiServer(t, "s", "alice", http.StatusOK, whoamiResponse{TokenType: "bearer"})
 	t.Cleanup(srv.Close)
-	ts, _ := NewGatewayTokenSource(GatewayTokenSourceConfig{
+	ts, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
 		EndpointURL: srv.URL + "/internal/v1/whoami",
 		Secret:      "s",
 		Subject:     "alice",
 		HTTPClient:  srv.Client(),
 	})
+	if err != nil {
+		t.Fatalf("NewGatewayTokenSource: %v", err)
+	}
 	if _, err := ts.Token(); err == nil || !strings.Contains(err.Error(), "access_token") {
 		t.Fatalf("expected access_token error, got %v", err)
 	}
@@ -193,12 +271,15 @@ func TestGatewayTokenSource_NoExpiry(t *testing.T) {
 		TokenType:   "bearer",
 	})
 	t.Cleanup(srv.Close)
-	ts, _ := NewGatewayTokenSource(GatewayTokenSourceConfig{
+	ts, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
 		EndpointURL: srv.URL + "/internal/v1/whoami",
 		Secret:      "s",
 		Subject:     "alice",
 		HTTPClient:  srv.Client(),
 	})
+	if err != nil {
+		t.Fatalf("NewGatewayTokenSource: %v", err)
+	}
 	tok, err := ts.Token()
 	if err != nil {
 		t.Fatalf("Token: %v", err)
@@ -257,12 +338,15 @@ func TestGatewayTokenSource_HTTPClientTimeout(t *testing.T) {
 	srv := httptest.NewServer(slowResponder{delay: 200 * time.Millisecond})
 	t.Cleanup(srv.Close)
 	hc := &http.Client{Timeout: 20 * time.Millisecond}
-	ts, _ := NewGatewayTokenSource(GatewayTokenSourceConfig{
+	ts, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
 		EndpointURL: srv.URL + "/internal/v1/whoami",
 		Secret:      "s",
 		Subject:     "alice",
 		HTTPClient:  hc,
 	})
+	if err != nil {
+		t.Fatalf("NewGatewayTokenSource: %v", err)
+	}
 	if _, err := ts.Token(); err == nil {
 		t.Fatal("expected timeout error, got nil")
 	}
@@ -281,13 +365,16 @@ func TestGatewayTokenSource_ParentContextCancelPropagates(t *testing.T) {
 	})
 	t.Cleanup(srv.Close)
 	parent, cancel := context.WithCancel(context.Background())
-	ts, _ := NewGatewayTokenSource(GatewayTokenSourceConfig{
+	ts, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
 		EndpointURL: srv.URL + "/internal/v1/whoami",
 		Secret:      "s",
 		Subject:     "alice",
 		HTTPClient:  srv.Client(),
 		Context:     parent,
 	})
+	if err != nil {
+		t.Fatalf("NewGatewayTokenSource: %v", err)
+	}
 	cancel()
 	if _, err := ts.Token(); err == nil {
 		t.Fatal("expected Token() to fail when parent context is cancelled, got nil")
@@ -304,12 +391,15 @@ func TestGatewayTokenSource_NoParentContext_StillWorks(t *testing.T) {
 		TokenType:   "bearer",
 	})
 	t.Cleanup(srv.Close)
-	ts, _ := NewGatewayTokenSource(GatewayTokenSourceConfig{
+	ts, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
 		EndpointURL: srv.URL + "/internal/v1/whoami",
 		Secret:      "s",
 		Subject:     "alice",
 		HTTPClient:  srv.Client(),
 	})
+	if err != nil {
+		t.Fatalf("NewGatewayTokenSource: %v", err)
+	}
 	if _, err := ts.Token(); err != nil {
 		t.Fatalf("Token: %v", err)
 	}

--- a/internal/github/gateway_token_source_test.go
+++ b/internal/github/gateway_token_source_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -342,8 +343,10 @@ func TestGatewayTokenSource_ReuseTokenSourceCachesUntilExpiry(t *testing.T) {
 	}
 }
 
-// slowReader pauses for the configured duration to simulate a slow gateway,
+// slowResponder pauses for the configured duration to simulate a slow gateway,
 // allowing the test to assert that the source's per-call timeout fires.
+// The body is a fully valid whoamiResponse (with expires_at) so any failure
+// must come from the timeout itself, not from validation falling through.
 type slowResponder struct {
 	delay time.Duration
 }
@@ -351,7 +354,8 @@ type slowResponder struct {
 func (s slowResponder) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	time.Sleep(s.delay)
 	w.WriteHeader(http.StatusOK)
-	_, _ = io.WriteString(w, `{"access_token":"x","token_type":"bearer"}`)
+	exp := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	_, _ = io.WriteString(w, `{"access_token":"x","token_type":"bearer","expires_at":"`+exp+`"}`)
 }
 
 func TestGatewayTokenSource_HTTPClientTimeout(t *testing.T) {
@@ -368,8 +372,17 @@ func TestGatewayTokenSource_HTTPClientTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewGatewayTokenSource: %v", err)
 	}
-	if _, err := ts.Token(); err == nil {
+	_, err = ts.Token()
+	if err == nil {
 		t.Fatal("expected timeout error, got nil")
+	}
+	// Must be a timeout, not (for example) ErrGatewayInvalidExpiry from a
+	// request that unexpectedly completed. http.Client.Timeout surfaces as
+	// a url.Error whose underlying err satisfies net.Error.Timeout(); the
+	// context deadline path satisfies errors.Is(err, context.DeadlineExceeded).
+	var nerr net.Error
+	if !(errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &nerr) && nerr.Timeout())) {
+		t.Fatalf("expected timeout error (context.DeadlineExceeded or net.Error.Timeout()=true), got %v", err)
 	}
 }
 
@@ -383,6 +396,7 @@ func TestGatewayTokenSource_ParentContextCancelPropagates(t *testing.T) {
 	srv := fakeWhoamiServer(t, "s", "alice", http.StatusOK, whoamiResponse{
 		AccessToken: "gho_x",
 		TokenType:   "bearer",
+		ExpiresAt:   time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
 	})
 	t.Cleanup(srv.Close)
 	parent, cancel := context.WithCancel(context.Background())
@@ -397,8 +411,14 @@ func TestGatewayTokenSource_ParentContextCancelPropagates(t *testing.T) {
 		t.Fatalf("NewGatewayTokenSource: %v", err)
 	}
 	cancel()
-	if _, err := ts.Token(); err == nil {
+	_, err = ts.Token()
+	if err == nil {
 		t.Fatal("expected Token() to fail when parent context is cancelled, got nil")
+	}
+	// Assert the cancellation actually propagated — not that the request
+	// completed and then failed validation (e.g. ErrGatewayInvalidExpiry).
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }
 

--- a/internal/github/gateway_token_source_test.go
+++ b/internal/github/gateway_token_source_test.go
@@ -1,0 +1,294 @@
+package ghclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestNewGatewayTokenSource_Validation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  GatewayTokenSourceConfig
+	}{
+		{name: "missing url", cfg: GatewayTokenSourceConfig{Secret: "s", Subject: "alice"}},
+		{name: "missing secret", cfg: GatewayTokenSourceConfig{EndpointURL: "http://127.0.0.1:1/x", Subject: "alice"}},
+		{name: "missing subject", cfg: GatewayTokenSourceConfig{EndpointURL: "http://127.0.0.1:1/x", Secret: "s"}},
+		{name: "bad scheme", cfg: GatewayTokenSourceConfig{EndpointURL: "ftp://127.0.0.1/x", Secret: "s", Subject: "alice"}},
+		{name: "non-loopback", cfg: GatewayTokenSourceConfig{EndpointURL: "http://example.com/x", Secret: "s", Subject: "alice"}},
+		{name: "non-loopback ip", cfg: GatewayTokenSourceConfig{EndpointURL: "http://10.0.0.1/x", Secret: "s", Subject: "alice"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := NewGatewayTokenSource(tc.cfg); err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestNewGatewayTokenSource_NonLoopbackError(t *testing.T) {
+	t.Parallel()
+	_, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
+		EndpointURL: "http://example.com/internal/v1/whoami",
+		Secret:      "supersecretsupersecretsupersecret",
+		Subject:     "alice",
+	})
+	if !errors.Is(err, ErrGatewayNonLoopback) {
+		t.Fatalf("expected ErrGatewayNonLoopback, got %v", err)
+	}
+}
+
+func TestNewGatewayTokenSource_AcceptsLoopbackVariants(t *testing.T) {
+	t.Parallel()
+	for _, host := range []string{"127.0.0.1", "[::1]", "localhost"} {
+		host := host
+		t.Run(host, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
+				EndpointURL: "http://" + host + ":1234/internal/v1/whoami",
+				Secret:      "s",
+				Subject:     "alice",
+			})
+			if err != nil {
+				t.Fatalf("unexpected error for host %q: %v", host, err)
+			}
+		})
+	}
+}
+
+// fakeWhoamiServer returns a test server that asserts the request shape and
+// responds with the configured status/body. respBody may be nil to omit body.
+func fakeWhoamiServer(t *testing.T, wantSecret, wantSubject string, status int, respBody any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method=%q, want POST", r.Method)
+		}
+		if r.URL.Path != "/internal/v1/whoami" {
+			t.Errorf("path=%q, want /internal/v1/whoami", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+wantSecret {
+			t.Errorf("Authorization=%q, want Bearer %s", got, wantSecret)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type=%q", got)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if body["subject"] != wantSubject {
+			t.Errorf("subject=%q, want %q", body["subject"], wantSubject)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if respBody != nil {
+			_ = json.NewEncoder(w).Encode(respBody)
+		}
+	}))
+}
+
+func TestGatewayTokenSource_HappyPath(t *testing.T) {
+	t.Parallel()
+	expiresAt := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
+	srv := fakeWhoamiServer(t, "secret-32-chars-long-XXXXXXXXXX01", "alice", http.StatusOK, whoamiResponse{
+		AccessToken: "gho_abc",
+		TokenType:   "bearer",
+		ExpiresAt:   expiresAt.Format(time.RFC3339),
+		Scopes:      []string{"repo"},
+	})
+	t.Cleanup(srv.Close)
+
+	ts, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
+		EndpointURL: srv.URL + "/internal/v1/whoami",
+		Secret:      "secret-32-chars-long-XXXXXXXXXX01",
+		Subject:     "alice",
+		HTTPClient:  srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewGatewayTokenSource: %v", err)
+	}
+	tok, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok.AccessToken != "gho_abc" {
+		t.Errorf("AccessToken=%q", tok.AccessToken)
+	}
+	if tok.TokenType != "bearer" {
+		t.Errorf("TokenType=%q", tok.TokenType)
+	}
+	if !tok.Expiry.Equal(expiresAt) {
+		t.Errorf("Expiry=%v, want %v", tok.Expiry, expiresAt)
+	}
+}
+
+func TestGatewayTokenSource_ErrorMappings(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		status int
+		want   error
+	}{
+		{"401", http.StatusUnauthorized, ErrGatewayUnauthorized},
+		{"403", http.StatusForbidden, ErrGatewayLoopbackRequired},
+		{"404", http.StatusNotFound, ErrGatewaySubjectGone},
+		{"502", http.StatusBadGateway, ErrGatewayUpstreamFailure},
+		{"400", http.StatusBadRequest, ErrGatewayBadRequest},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := fakeWhoamiServer(t, "s", "alice", tc.status, map[string]string{"code": "x"})
+			t.Cleanup(srv.Close)
+			ts, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
+				EndpointURL: srv.URL + "/internal/v1/whoami",
+				Secret:      "s",
+				Subject:     "alice",
+				HTTPClient:  srv.Client(),
+			})
+			if err != nil {
+				t.Fatalf("NewGatewayTokenSource: %v", err)
+			}
+			_, err = ts.Token()
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("err=%v, want errors.Is %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestGatewayTokenSource_MissingAccessToken(t *testing.T) {
+	t.Parallel()
+	srv := fakeWhoamiServer(t, "s", "alice", http.StatusOK, whoamiResponse{TokenType: "bearer"})
+	t.Cleanup(srv.Close)
+	ts, _ := NewGatewayTokenSource(GatewayTokenSourceConfig{
+		EndpointURL: srv.URL + "/internal/v1/whoami",
+		Secret:      "s",
+		Subject:     "alice",
+		HTTPClient:  srv.Client(),
+	})
+	if _, err := ts.Token(); err == nil || !strings.Contains(err.Error(), "access_token") {
+		t.Fatalf("expected access_token error, got %v", err)
+	}
+}
+
+func TestGatewayTokenSource_NoExpiry(t *testing.T) {
+	t.Parallel()
+	srv := fakeWhoamiServer(t, "s", "alice", http.StatusOK, whoamiResponse{
+		AccessToken: "gho_x",
+		TokenType:   "bearer",
+	})
+	t.Cleanup(srv.Close)
+	ts, _ := NewGatewayTokenSource(GatewayTokenSourceConfig{
+		EndpointURL: srv.URL + "/internal/v1/whoami",
+		Secret:      "s",
+		Subject:     "alice",
+		HTTPClient:  srv.Client(),
+	})
+	tok, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if !tok.Expiry.IsZero() {
+		t.Errorf("Expiry=%v, want zero", tok.Expiry)
+	}
+}
+
+func TestGatewayTokenSource_ReuseTokenSourceCachesUntilExpiry(t *testing.T) {
+	t.Parallel()
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_ = json.NewEncoder(w).Encode(whoamiResponse{
+			AccessToken: "gho_n",
+			TokenType:   "bearer",
+			ExpiresAt:   time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		})
+	}))
+	t.Cleanup(srv.Close)
+	ts, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
+		EndpointURL: srv.URL + "/internal/v1/whoami",
+		Secret:      "s",
+		Subject:     "alice",
+		HTTPClient:  srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewGatewayTokenSource: %v", err)
+	}
+	reuse := oauth2.ReuseTokenSource(nil, ts)
+	for i := 0; i < 5; i++ {
+		if _, err := reuse.Token(); err != nil {
+			t.Fatalf("Token #%d: %v", i, err)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("whoami calls=%d, want 1 (ReuseTokenSource should cache)", calls)
+	}
+}
+
+// slowReader pauses for the configured duration to simulate a slow gateway,
+// allowing the test to assert that the source's per-call timeout fires.
+type slowResponder struct {
+	delay time.Duration
+}
+
+func (s slowResponder) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	time.Sleep(s.delay)
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, `{"access_token":"x","token_type":"bearer"}`)
+}
+
+func TestGatewayTokenSource_HTTPClientTimeout(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(slowResponder{delay: 200 * time.Millisecond})
+	t.Cleanup(srv.Close)
+	hc := &http.Client{Timeout: 20 * time.Millisecond}
+	ts, _ := NewGatewayTokenSource(GatewayTokenSourceConfig{
+		EndpointURL: srv.URL + "/internal/v1/whoami",
+		Secret:      "s",
+		Subject:     "alice",
+		HTTPClient:  hc,
+	})
+	if _, err := ts.Token(); err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+// Sanity: ensure context derivation does not leak — Token uses its own
+// internal timeout context.
+func TestGatewayTokenSource_NoContextLeak(t *testing.T) {
+	t.Parallel()
+	srv := fakeWhoamiServer(t, "s", "alice", http.StatusOK, whoamiResponse{
+		AccessToken: "gho_x",
+		TokenType:   "bearer",
+	})
+	t.Cleanup(srv.Close)
+	ts, _ := NewGatewayTokenSource(GatewayTokenSourceConfig{
+		EndpointURL: srv.URL + "/internal/v1/whoami",
+		Secret:      "s",
+		Subject:     "alice",
+		HTTPClient:  srv.Client(),
+	})
+	// Even with a cancelled parent context elsewhere, Token() must succeed
+	// because it builds its own context.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = ctx
+	if _, err := ts.Token(); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+}

--- a/internal/github/gateway_token_source_test.go
+++ b/internal/github/gateway_token_source_test.go
@@ -264,8 +264,11 @@ func TestGatewayTokenSource_MissingAccessToken(t *testing.T) {
 	}
 }
 
-func TestGatewayTokenSource_NoExpiry(t *testing.T) {
+func TestGatewayTokenSource_MissingExpiry_Errors(t *testing.T) {
 	t.Parallel()
+	// Gateway response with no expires_at must fail closed: returning a
+	// zero Expiry would let oauth2.ReuseTokenSource cache the token
+	// forever and silently disable refresh after the real token expires.
 	srv := fakeWhoamiServer(t, "s", "alice", http.StatusOK, whoamiResponse{
 		AccessToken: "gho_x",
 		TokenType:   "bearer",
@@ -280,12 +283,30 @@ func TestGatewayTokenSource_NoExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewGatewayTokenSource: %v", err)
 	}
-	tok, err := ts.Token()
-	if err != nil {
-		t.Fatalf("Token: %v", err)
+	if _, err := ts.Token(); !errors.Is(err, ErrGatewayInvalidExpiry) {
+		t.Fatalf("expected ErrGatewayInvalidExpiry, got %v", err)
 	}
-	if !tok.Expiry.IsZero() {
-		t.Errorf("Expiry=%v, want zero", tok.Expiry)
+}
+
+func TestGatewayTokenSource_InvalidExpiry_Errors(t *testing.T) {
+	t.Parallel()
+	srv := fakeWhoamiServer(t, "s", "alice", http.StatusOK, whoamiResponse{
+		AccessToken: "gho_x",
+		TokenType:   "bearer",
+		ExpiresAt:   "not-a-timestamp",
+	})
+	t.Cleanup(srv.Close)
+	ts, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
+		EndpointURL: srv.URL + "/internal/v1/whoami",
+		Secret:      "s",
+		Subject:     "alice",
+		HTTPClient:  srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewGatewayTokenSource: %v", err)
+	}
+	if _, err := ts.Token(); !errors.Is(err, ErrGatewayInvalidExpiry) {
+		t.Fatalf("expected ErrGatewayInvalidExpiry, got %v", err)
 	}
 }
 
@@ -389,6 +410,7 @@ func TestGatewayTokenSource_NoParentContext_StillWorks(t *testing.T) {
 	srv := fakeWhoamiServer(t, "s", "alice", http.StatusOK, whoamiResponse{
 		AccessToken: "gho_x",
 		TokenType:   "bearer",
+		ExpiresAt:   time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
 	})
 	t.Cleanup(srv.Close)
 	ts, err := NewGatewayTokenSource(GatewayTokenSourceConfig{

--- a/internal/github/gateway_token_source_test.go
+++ b/internal/github/gateway_token_source_test.go
@@ -268,9 +268,36 @@ func TestGatewayTokenSource_HTTPClientTimeout(t *testing.T) {
 	}
 }
 
-// Sanity: ensure context derivation does not leak — Token uses its own
-// internal timeout context.
-func TestGatewayTokenSource_NoContextLeak(t *testing.T) {
+// Verify that watch cancellation propagates: when the parent context passed
+// via GatewayTokenSourceConfig.Context is cancelled, Token() must fail rather
+// than complete the whoami round-trip. Aligns Token's semantics with the
+// Phase B PR-A goal of letting watch/server shutdown stop in-flight token
+// refresh.
+func TestGatewayTokenSource_ParentContextCancelPropagates(t *testing.T) {
+	t.Parallel()
+	srv := fakeWhoamiServer(t, "s", "alice", http.StatusOK, whoamiResponse{
+		AccessToken: "gho_x",
+		TokenType:   "bearer",
+	})
+	t.Cleanup(srv.Close)
+	parent, cancel := context.WithCancel(context.Background())
+	ts, _ := NewGatewayTokenSource(GatewayTokenSourceConfig{
+		EndpointURL: srv.URL + "/internal/v1/whoami",
+		Secret:      "s",
+		Subject:     "alice",
+		HTTPClient:  srv.Client(),
+		Context:     parent,
+	})
+	cancel()
+	if _, err := ts.Token(); err == nil {
+		t.Fatal("expected Token() to fail when parent context is cancelled, got nil")
+	}
+}
+
+// When no parent context is configured (nil Context), Token() must still
+// succeed using context.Background(): existing callers that pre-date the
+// Context field continue to work.
+func TestGatewayTokenSource_NoParentContext_StillWorks(t *testing.T) {
 	t.Parallel()
 	srv := fakeWhoamiServer(t, "s", "alice", http.StatusOK, whoamiResponse{
 		AccessToken: "gho_x",
@@ -283,11 +310,6 @@ func TestGatewayTokenSource_NoContextLeak(t *testing.T) {
 		Subject:     "alice",
 		HTTPClient:  srv.Client(),
 	})
-	// Even with a cancelled parent context elsewhere, Token() must succeed
-	// because it builds its own context.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	_ = ctx
 	if _, err := ts.Token(); err != nil {
 		t.Fatalf("Token: %v", err)
 	}

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -129,7 +129,7 @@ func (h *StreamableHandler) Close() {
 }
 
 // BuilderOptions configures optional behaviors for BuildStreamableHandlerWithOptions.
-// Unset fields fall back to defaults that preserve v3.0.x behavior.
+// Unset fields fall back to defaults that preserve current behavior.
 type BuilderOptions struct {
 	// GatewayClientFactory, if non-nil, overrides the default static-token
 	// watch ClientFactory. It is invoked per watch with the authenticated

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -128,11 +128,28 @@ func (h *StreamableHandler) Close() {
 	})
 }
 
+// BuilderOptions configures optional behaviors for BuildStreamableHandlerWithOptions.
+// Unset fields fall back to defaults that preserve v3.0.x behavior.
+type BuilderOptions struct {
+	// GatewayClientFactory, if non-nil, overrides the default static-token
+	// watch ClientFactory. It is invoked per watch with the authenticated
+	// GitHub session token and login. Used by Phase B delegated background
+	// access (see scottlz0310/copilot-review-mcp#29).
+	GatewayClientFactory func(ctx context.Context, token, login string) watch.ReviewDataFetcher
+}
+
 // BuildStreamableHandler returns a handler that serves MCP over Streamable HTTP.
 // getServer is called for new stateful MCP sessions and returns the shared
 // long-lived *mcp.Server. GitHub clients are created per tool call from the
 // authenticated request headers.
 func BuildStreamableHandler(db *store.DB, threshold time.Duration) *StreamableHandler {
+	return BuildStreamableHandlerWithOptions(db, threshold, BuilderOptions{})
+}
+
+// BuildStreamableHandlerWithOptions is the option-accepting variant of
+// BuildStreamableHandler. Callers that need Phase B gateway delegated
+// background access should use this entry point.
+func BuildStreamableHandlerWithOptions(db *store.DB, threshold time.Duration, opts BuilderOptions) *StreamableHandler {
 	clientProvider := newGitHubClientProvider(threshold, nil)
 	// watchManager is declared before srv so the SubscribeHandler closure can reference it
 	// for authorization. At the time any subscribe request arrives the server is already
@@ -174,6 +191,7 @@ func BuildStreamableHandler(db *store.DB, threshold time.Duration) *StreamableHa
 	watchManager = watch.NewManager(db, watch.Options{
 		Threshold:       threshold,
 		InvalidateToken: nil,
+		ClientFactory:   opts.GatewayClientFactory,
 		NotifyResourceUpdated: func(uri string) {
 			if err := srv.ResourceUpdated(context.Background(), &mcp.ResourceUpdatedNotificationParams{URI: uri}); err != nil {
 				slog.Warn("resource updated notification failed", "uri", uri, "err", err)

--- a/internal/tools/watch_test.go
+++ b/internal/tools/watch_test.go
@@ -24,7 +24,7 @@ func TestGetWatchStatusHandlerScopesWatchIDByLogin(t *testing.T) {
 	manager := watch.NewManager(db, watch.Options{
 		PollInterval: time.Hour,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) watch.ReviewDataFetcher {
 			return testStaticFetcher{}
 		},
 	})
@@ -59,7 +59,7 @@ func TestGetWatchStatusHandlerReturnsLLMHints(t *testing.T) {
 	manager := watch.NewManager(db, watch.Options{
 		PollInterval: time.Hour,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) watch.ReviewDataFetcher {
 			return testStaticFetcher{}
 		},
 	})
@@ -112,7 +112,7 @@ func TestListWatchesHandlerReturnsSortedViews(t *testing.T) {
 		Now: func() time.Time {
 			return base
 		},
-		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) watch.ReviewDataFetcher {
 			return testStaticFetcher{}
 		},
 	})
@@ -175,7 +175,7 @@ func TestCancelWatchHandlerCancelsByPRKey(t *testing.T) {
 	manager := watch.NewManager(db, watch.Options{
 		PollInterval: time.Hour,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) watch.ReviewDataFetcher {
 			return testStaticFetcher{}
 		},
 	})
@@ -321,7 +321,7 @@ func TestWatchResourceHandlerScopesWatchIDByLogin(t *testing.T) {
 	manager := watch.NewManager(db, watch.Options{
 		PollInterval: time.Hour,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) watch.ReviewDataFetcher {
 			return testStaticFetcher{}
 		},
 	})
@@ -384,7 +384,7 @@ func TestWatchResourceHandlerReturnsJSON(t *testing.T) {
 	manager := watch.NewManager(db, watch.Options{
 		PollInterval: time.Hour,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) watch.ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) watch.ReviewDataFetcher {
 			return testStaticFetcher{}
 		},
 	})

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -90,7 +90,7 @@ type Options struct {
 	MaxWatchDuration time.Duration
 	Threshold        time.Duration
 	InvalidateToken  func(string)
-	ClientFactory    func(ctx context.Context, token string) ReviewDataFetcher
+	ClientFactory    func(ctx context.Context, token, login string) ReviewDataFetcher
 	Now              func() time.Time
 	// NotifyResourceUpdated is called asynchronously whenever a watch transitions
 	// state. The uri argument is the resource URI of the changed watch
@@ -132,7 +132,7 @@ type Manager struct {
 	pollTimeout           time.Duration
 	maxWatchDuration      time.Duration
 	notifyResourceUpdated func(uri string)
-	clientFactory         func(ctx context.Context, token string) ReviewDataFetcher
+	clientFactory         func(ctx context.Context, token, login string) ReviewDataFetcher
 	now                   func() time.Time
 	ctx                   context.Context
 	cancel                context.CancelFunc
@@ -197,7 +197,7 @@ func NewManager(db watchStore, opts Options) *Manager {
 	ctx, cancel := context.WithCancel(context.Background())
 	clientFactory := opts.ClientFactory
 	if clientFactory == nil {
-		clientFactory = func(ctx context.Context, token string) ReviewDataFetcher {
+		clientFactory = func(ctx context.Context, token, _ string) ReviewDataFetcher {
 			return ghclient.NewClient(ctx, token, opts.Threshold, opts.InvalidateToken)
 		}
 	}
@@ -300,7 +300,7 @@ func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 			if tokenChanged {
 				existing.token = in.Token
 				existing.clientMu.Lock()
-				existing.client = m.clientFactory(existing.ctx, in.Token)
+				existing.client = m.clientFactory(existing.ctx, in.Token, key.login)
 				existing.clientMu.Unlock()
 			}
 			if triggerLinked {
@@ -328,7 +328,7 @@ func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 		token:         in.Token,
 		ctx:           watchCtx,
 		cancel:        cancel,
-		client:        m.clientFactory(watchCtx, in.Token),
+		client:        m.clientFactory(watchCtx, in.Token, key.login),
 		status:        StatusWatching,
 		workerRunning: true,
 		startedAt:     now,

--- a/internal/watch/manager_test.go
+++ b/internal/watch/manager_test.go
@@ -22,7 +22,7 @@ func TestManagerStartReusesActiveWatch(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: 5 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
@@ -69,7 +69,7 @@ func TestManagerStartPersistsActiveWatch(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: time.Hour,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
@@ -128,7 +128,7 @@ func TestManagerReuseWithTriggerLinkUpdatesTimestamp(t *testing.T) {
 		PollInterval: time.Hour,
 		Threshold:    30 * time.Second,
 		Now:          nowFn,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
@@ -198,7 +198,7 @@ func TestManagerMarksCompletedAndClearsActiveKey(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: 5 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{
@@ -266,7 +266,7 @@ func TestManagerAuthExpiredFailsWatch(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: 5 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{err: &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusUnauthorized}}},
@@ -303,7 +303,7 @@ func TestManagerCloseMarksActiveWatchStale(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: 50 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
@@ -361,7 +361,7 @@ func TestManagerPersistFailureDuringPollingFailsWatch(t *testing.T) {
 	}, Options{
 		PollInterval: 5 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
@@ -406,7 +406,7 @@ func TestManagerPersistFailureDuringTerminalTransitionFailsWatch(t *testing.T) {
 	}, Options{
 		PollInterval: 5 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{
@@ -458,7 +458,7 @@ func TestManagerCloseKeepsStaleStatusWhenPersistenceFails(t *testing.T) {
 	}, Options{
 		PollInterval: 50 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
@@ -499,7 +499,7 @@ func TestManagerGetLatestFallsBackToPersistedWatch(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: 5 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{
@@ -553,7 +553,7 @@ func TestManagerListReturnsActiveFirstAndIncludesPersistedWatch(t *testing.T) {
 		Now: func() time.Time {
 			return base
 		},
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
@@ -612,7 +612,7 @@ func TestManagerCancelLatestMarksWatchCancelled(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: time.Hour,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
@@ -677,7 +677,7 @@ func TestManagerPollTimeoutFailsWatch(t *testing.T) {
 		PollInterval: 5 * time.Millisecond,
 		PollTimeout:  10 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return blockingFetcher{}
 		},
 	})
@@ -738,7 +738,7 @@ func TestManagerMaxWatchDurationTransitionsToTimeout(t *testing.T) {
 		MaxWatchDuration: 1 * time.Millisecond,
 		Threshold:        30 * time.Second,
 		Now:              nowFn,
-		ClientFactory:    func(_ context.Context, _ string) ReviewDataFetcher { return fetcher },
+		ClientFactory:    func(_ context.Context, _, _ string) ReviewDataFetcher { return fetcher },
 	})
 	t.Cleanup(manager.Close)
 
@@ -776,7 +776,7 @@ func TestManagerLowRateLimitIncludesRetryDetail(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: 5 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{
@@ -949,7 +949,7 @@ func TestManagerNotifyResourceUpdatedCalledOnTerminal(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: 5 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{
@@ -1016,7 +1016,7 @@ func TestManagerNotifyResourceUpdatedCalledOnReviewStatusChange(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: 5 * time.Millisecond,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					// First poll: PENDING (no review yet)
@@ -1182,7 +1182,7 @@ func TestManagerCancelLatestClearsTriggerLogPending(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: time.Hour,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
@@ -1242,7 +1242,7 @@ func TestManagerCancelByIDClearsTriggerLogPending(t *testing.T) {
 	manager := NewManager(db, Options{
 		PollInterval: time.Hour,
 		Threshold:    30 * time.Second,
-		ClientFactory: func(_ context.Context, _ string) ReviewDataFetcher {
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},


### PR DESCRIPTION
## Summary

Phase B 委譲バックグラウンドアクセスのクライアントコア (PR-A) を実装。長時間動作する watch goroutine が gateway 経由で rotated token を透過的に取得できるようにする opt-in 機能。

Refs: #29
Depends on: scottlz0310/mcp-gateway#76 (merged)

## Scope: PR-A only

合意済み分割:

- **PR-A (this)**: gatewayTokenSource + opt-in 配線 + unit test
- **PR-B (deferred)**: 404 → `FailureReasonAuthExpired` マッピング、`InvalidateToken` 活性化
- **PR-C (deferred)**: gateway 起動の integration test
- **PR-D (deferred)**: Phase C 構造化エラー契約（gateway Phase C 待ち）

## Changes

- `internal/github/gateway_token_source.go`: `oauth2.TokenSource` 実装。POST /internal/v1/whoami を `Bearer <secret>` で叩き、`expires_at` を `oauth2.Token.Expiry` に反映。loopback (127.0.0.1/`::1`/`localhost`) を**クライアント側でも**検証（多重防御）。10s タイムアウト（`ghclient.DefaultGatewayTimeout`、context deadline と http.Client.Timeout の両方）。401/403/404/502/4xx ごとに sentinel error を返す（マッピングは PR-B）。
- `internal/github/client.go`: 動的トークン用 `NewClientWithTokenSource(ctx, ts, threshold)` を追加。`invalidatingTransport` は意図的に未付与（PR-B）。
- `internal/tools/server.go`: `BuilderOptions{GatewayClientFactory}` と `BuildStreamableHandlerWithOptions` を新設。既存 `BuildStreamableHandler(db, threshold)` のシグネチャは維持。
- `cmd/server/main.go`: `COPILOT_REVIEW_GATEWAY_INTERNAL_URL` + `COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET` 両方設定時のみ opt-in。**片方のみ設定された場合は fail-closed で起動中断**（silent fallback しない）。subject は認証済み GitHub login。`oauth2.ReuseTokenSource(nil, ts)` で watch ごとにラップ。
- `internal/watch/manager.go`: `ClientFactory` を `func(ctx, token, login string)` に拡張。テストは機械的更新。

## Default behavior preserved

両 env 未設定時は従来通り `oauth2.StaticTokenSource` を使用するため、既存デプロイには影響なし。

## Limitation

PoC は client と gateway が同一ホスト (loopback) 必須。複数コンテナの Docker Compose 構成は PR-A では非対応（`docs/spike-72-delegated-background-access.md` "Future work" 参照）。

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...` — all packages pass
- `golangci-lint run ./...` — 既存指摘のみ、本 PR で新規 issue なし

## Tests

`internal/github/gateway_token_source_test.go`:

- バリデーション (empty URL/secret/subject、bad scheme、non-loopback host)
- loopback バリアント (`127.0.0.1`、`::1`、`localhost`)
- happy path (`expires_at` を `Token.Expiry` に反映)
- エラーマッピング (401/403/404/502/4xx)
- `access_token` 欠落
- `expires_at` 未指定
- `ReuseTokenSource` キャッシュ動作
- HTTP timeout
- context キャンセル伝搬
