### PR TITLE
fix(github): parse gateway 502 body to distinguish rotation_failed from upstream_failure

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,7 +34,7 @@ func main() {
 		slog.Error("failed to open SQLite database", "path", cfg.sqlitePath, "err", err)
 		os.Exit(1)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	slog.Info("auth mode: gateway (trusting X-Authenticated-User header from mcp-gateway)")
 
@@ -57,7 +57,7 @@ func main() {
 	// Health check (no auth required)
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, `{"status":"ok"}`)
+		_, _ = fmt.Fprintln(w, `{"status":"ok"}`)
 	})
 
 	// MCP endpoints (auth required) — Streamable HTTP transport (stateful, shared server)

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -112,7 +112,7 @@ func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
 		switch {
 		case strings.Contains(normalizedQuery, "pullRequest(number:$pr)") && strings.Contains(normalizedQuery, "id"):
 			sawNodeIDQuery.Store(true)
-			fmt.Fprintf(w, `{"data":{"repository":{"pullRequest":{"id":%q}}}}`, prNodeID)
+			_, _ = fmt.Fprintf(w, `{"data":{"repository":{"pullRequest":{"id":%q}}}}`, prNodeID)
 		case strings.Contains(normalizedQuery, "requestReviewsByLogin(input:$input)"):
 			sawRequestMutation.Store(true)
 			if !strings.Contains(normalizedQuery, "RequestReviewsByLoginInput") {
@@ -150,9 +150,9 @@ func TestRequestCopilotReviewUsesRequestReviewsByLoginInput(t *testing.T) {
 				t.Error("input.union = false, want true")
 			}
 
-			fmt.Fprint(w, `{"data":{"requestReviewsByLogin":{"clientMutationId":""}}}`)
+			_, _ = fmt.Fprint(w, `{"data":{"requestReviewsByLogin":{"clientMutationId":""}}}`)
 		default:
-			fmt.Fprint(w, `{"data":{}}`)
+			_, _ = fmt.Fprint(w, `{"data":{}}`)
 		}
 	}))
 	defer srv.Close()
@@ -519,11 +519,11 @@ func TestGetCIStatus(t *testing.T) {
 			mux := http.NewServeMux()
 			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, pr), func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprint(w, prJSON)
+				_, _ = fmt.Fprint(w, prJSON)
 			})
 			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs", owner, repo, sha), func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprint(w, tt.checksJSON)
+				_, _ = fmt.Fprint(w, tt.checksJSON)
 			})
 
 			c, teardown := newTestGHClient(mux)
@@ -545,7 +545,7 @@ func TestGetCIStatus(t *testing.T) {
 
 		mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, pr), func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, prJSON)
+			_, _ = fmt.Fprint(w, prJSON)
 		})
 		mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs", owner, repo, sha), func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -556,10 +556,10 @@ func TestGetCIStatus(t *testing.T) {
 			pagesSeen = append(pagesSeen, page)
 			if page == "1" {
 				w.Header().Set("Link", fmt.Sprintf(`<http://%s/repos/%s/%s/commits/%s/check-runs?page=2>; rel="next"`, r.Host, owner, repo, sha))
-				fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":1,"status":"completed","conclusion":"success"}]}`)
+				_, _ = fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":1,"status":"completed","conclusion":"success"}]}`)
 				return
 			}
-			fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":2,"status":"completed","conclusion":"failure"}]}`)
+			_, _ = fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":2,"status":"completed","conclusion":"failure"}]}`)
 		})
 
 		c, teardown := newTestGHClient(mux)
@@ -583,7 +583,7 @@ func TestGetCIStatus(t *testing.T) {
 
 		mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, pr), func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, prJSON)
+			_, _ = fmt.Fprint(w, prJSON)
 		})
 		mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs", owner, repo, sha), func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -594,10 +594,10 @@ func TestGetCIStatus(t *testing.T) {
 			pagesSeen = append(pagesSeen, page)
 			if page == "1" {
 				w.Header().Set("Link", fmt.Sprintf(`<http://%s/repos/%s/%s/commits/%s/check-runs?page=2>; rel="next"`, r.Host, owner, repo, sha))
-				fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":1,"status":"completed","conclusion":"success"}]}`)
+				_, _ = fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":1,"status":"completed","conclusion":"success"}]}`)
 				return
 			}
-			fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":2,"status":"completed","conclusion":"success"}]}`)
+			_, _ = fmt.Fprint(w, `{"total_count":2,"check_runs":[{"id":2,"status":"completed","conclusion":"success"}]}`)
 		})
 
 		c, teardown := newTestGHClient(mux)
@@ -650,7 +650,7 @@ func TestGetReviewDataTimeline(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("X-RateLimit-Remaining", "100")
 		w.Header().Set("X-RateLimit-Reset", "9999999999")
-		fmt.Fprint(w, body)
+		_, _ = fmt.Fprint(w, body)
 	}
 
 	mux := http.NewServeMux()
@@ -724,7 +724,7 @@ func TestGetReviewDataTimelinePicksLatestEvents(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("X-RateLimit-Remaining", "100")
 		w.Header().Set("X-RateLimit-Reset", "9999999999")
-		fmt.Fprint(w, body)
+		_, _ = fmt.Fprint(w, body)
 	}
 
 	mux := http.NewServeMux()

--- a/internal/github/gateway_token_source.go
+++ b/internal/github/gateway_token_source.go
@@ -292,7 +292,7 @@ func (g *gatewayTokenSource) Token() (*oauth2.Token, error) {
 			Error string `json:"error"`
 		}
 		_ = json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&gatewayErr)
-		_, _ = io.Copy(io.Discard, resp.Body) // drain any remainder
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16)) // drain any remainder
 		if gatewayErr.Error == "rotation_failed" {
 			return nil, ErrGatewayRotationFailed
 		}

--- a/internal/github/gateway_token_source.go
+++ b/internal/github/gateway_token_source.go
@@ -37,9 +37,17 @@ var (
 	// generally means client and gateway are not co-located on the same host.
 	ErrGatewayLoopbackRequired = errors.New("gateway: loopback required (403)")
 
-	// ErrGatewayUpstreamFailure indicates the gateway tried to rotate the
-	// token but the GitHub OAuth provider failed (HTTP 502). Retryable.
-	ErrGatewayUpstreamFailure = errors.New("gateway: upstream rotation failure (502)")
+	// ErrGatewayRotationFailed indicates the gateway tried to rotate the
+	// refresh token but the GitHub OAuth provider explicitly rejected it
+	// (HTTP 502 with body {"error":"rotation_failed"}). This is NOT
+	// transient: the user must re-authenticate to obtain a fresh refresh
+	// token. Distinct from ErrGatewayUpstreamFailure, which is retryable.
+	ErrGatewayRotationFailed = errors.New("gateway: refresh token rotation rejected (502/rotation_failed)")
+
+	// ErrGatewayUpstreamFailure indicates a transient upstream failure
+	// (HTTP 502 with body {"error":"upstream_failure"} or unrecognised
+	// body). Retry may succeed; if the error persists, re-authenticate.
+	ErrGatewayUpstreamFailure = errors.New("gateway: transient upstream failure (502)")
 
 	// ErrGatewayBadRequest covers 4xx responses that are neither 401/403/404.
 	ErrGatewayBadRequest = errors.New("gateway: bad request (4xx)")
@@ -264,26 +272,33 @@ func (g *gatewayTokenSource) Token() (*oauth2.Token, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		// Drain a bounded portion of the body so net/http can reuse the
-		// underlying connection on keep-alive. Errors here are ignored;
-		// connection reuse is best-effort, and we still want to surface
-		// the original status-derived error to the caller below.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
-	}
-
 	switch resp.StatusCode {
 	case http.StatusOK:
-		// fallthrough below
+		// fallthrough below; body is read after the switch
 	case http.StatusUnauthorized:
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
 		return nil, ErrGatewayUnauthorized
 	case http.StatusForbidden:
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
 		return nil, ErrGatewayLoopbackRequired
 	case http.StatusNotFound:
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
 		return nil, ErrGatewaySubjectGone
 	case http.StatusBadGateway:
+		// Parse the gateway error body to distinguish rotation_failed (must
+		// re-auth) from upstream_failure (transient, retry may succeed). The
+		// blanket drain was moved here so 502 body is still available (#33).
+		var gatewayErr struct {
+			Error string `json:"error"`
+		}
+		_ = json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&gatewayErr)
+		_, _ = io.Copy(io.Discard, resp.Body) // drain any remainder
+		if gatewayErr.Error == "rotation_failed" {
+			return nil, ErrGatewayRotationFailed
+		}
 		return nil, ErrGatewayUpstreamFailure
 	default:
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
 		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
 			return nil, fmt.Errorf("%w: status=%d", ErrGatewayBadRequest, resp.StatusCode)
 		}

--- a/internal/github/gateway_token_source_test.go
+++ b/internal/github/gateway_token_source_test.go
@@ -216,19 +216,25 @@ func TestGatewayTokenSource_ErrorMappings(t *testing.T) {
 	cases := []struct {
 		name   string
 		status int
+		body   any
 		want   error
 	}{
-		{"401", http.StatusUnauthorized, ErrGatewayUnauthorized},
-		{"403", http.StatusForbidden, ErrGatewayLoopbackRequired},
-		{"404", http.StatusNotFound, ErrGatewaySubjectGone},
-		{"502", http.StatusBadGateway, ErrGatewayUpstreamFailure},
-		{"400", http.StatusBadRequest, ErrGatewayBadRequest},
+		{"401", http.StatusUnauthorized, map[string]string{"code": "x"}, ErrGatewayUnauthorized},
+		{"403", http.StatusForbidden, map[string]string{"code": "x"}, ErrGatewayLoopbackRequired},
+		{"404", http.StatusNotFound, map[string]string{"code": "x"}, ErrGatewaySubjectGone},
+		// 502 body parse: rotation_failed → ErrGatewayRotationFailed (#33)
+		{"502/rotation_failed", http.StatusBadGateway, map[string]string{"error": "rotation_failed"}, ErrGatewayRotationFailed},
+		// 502 body parse: upstream_failure → ErrGatewayUpstreamFailure (#33)
+		{"502/upstream_failure", http.StatusBadGateway, map[string]string{"error": "upstream_failure"}, ErrGatewayUpstreamFailure},
+		// 502 with unknown / non-JSON body → fallback to ErrGatewayUpstreamFailure
+		{"502/unknown_body", http.StatusBadGateway, map[string]string{"code": "x"}, ErrGatewayUpstreamFailure},
+		{"400", http.StatusBadRequest, map[string]string{"code": "x"}, ErrGatewayBadRequest},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			srv := fakeWhoamiServer(t, "s", "alice", tc.status, map[string]string{"code": "x"})
+			srv := fakeWhoamiServer(t, "s", "alice", tc.status, tc.body)
 			t.Cleanup(srv.Close)
 			ts, err := NewGatewayTokenSource(GatewayTokenSourceConfig{
 				EndpointURL: srv.URL + "/internal/v1/whoami",

--- a/internal/github/gateway_token_source_test.go
+++ b/internal/github/gateway_token_source_test.go
@@ -387,7 +387,8 @@ func TestGatewayTokenSource_HTTPClientTimeout(t *testing.T) {
 	// a url.Error whose underlying err satisfies net.Error.Timeout(); the
 	// context deadline path satisfies errors.Is(err, context.DeadlineExceeded).
 	var nerr net.Error
-	if !(errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &nerr) && nerr.Timeout())) {
+	isTimeout := errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &nerr) && nerr.Timeout())
+	if !isTimeout {
 		t.Fatalf("expected timeout error (context.DeadlineExceeded or net.Error.Timeout()=true), got %v", err)
 	}
 }

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -70,11 +70,11 @@ func Open(path string) (*DB, error) {
 	db.SetMaxIdleConns(1)
 	// Enable WAL mode for better concurrent access.
 	if _, err := db.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;"); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, err
 	}
 	if _, err := db.Exec(schema); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, err
 	}
 	// Migration: add prev_review_id column for ID-based review staleness detection.
@@ -83,7 +83,7 @@ func Open(path string) (*DB, error) {
 	var colExists bool
 	rows, err := db.Query(`PRAGMA table_info(trigger_log)`)
 	if err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("migration check table_info: %w", err)
 	}
 	for rows.Next() {
@@ -92,8 +92,8 @@ func Open(path string) (*DB, error) {
 		var notNull, pk int
 		var dfltValue interface{}
 		if err := rows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
-			rows.Close()
-			db.Close()
+			_ = rows.Close()
+			_ = db.Close()
 			return nil, fmt.Errorf("migration scan table_info: %w", err)
 		}
 		if name == "prev_review_id" {
@@ -102,27 +102,27 @@ func Open(path string) (*DB, error) {
 		}
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
-		db.Close()
+		_ = rows.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("migration iterate table_info: %w", err)
 	}
 	if err := rows.Close(); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("migration close table_info rows: %w", err)
 	}
 	if !colExists {
 		if _, err := db.Exec(`ALTER TABLE trigger_log ADD COLUMN prev_review_id TEXT`); err != nil {
-			db.Close()
+			_ = db.Close()
 			return nil, fmt.Errorf("migration add prev_review_id: %w", err)
 		}
 	}
 	if _, err := db.Exec(reviewWatchLookupIndexSQL); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, err
 	}
 	d := &DB{db: db}
 	if _, err := d.MarkActiveReviewWatchesStale(staleOnOpenMessage); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, err
 	}
 	return d, nil
@@ -378,7 +378,7 @@ func (d *DB) ListReviewWatches(filter ReviewWatchFilter) ([]ReviewWatchEntry, er
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var entries []ReviewWatchEntry
 	for rows.Next() {

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -333,7 +333,7 @@ func TestOpenMarksActiveReviewWatchesStale(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store.Open(reopen) error = %v", err)
 	}
-	defer reopened.Close()
+	defer func() { _ = reopened.Close() }()
 
 	got, err := reopened.GetReviewWatchByID(entry.ID)
 	if err != nil {

--- a/internal/tools/request_test.go
+++ b/internal/tools/request_test.go
@@ -32,9 +32,9 @@ func newGitHubAPIMock(t *testing.T, submittedAt time.Time) *httptest.Server {
 		w.Header().Set("X-RateLimit-Remaining", "1000")
 		switch {
 		case strings.Contains(r.URL.Path, "/requested_reviewers") && r.Method == http.MethodGet:
-			fmt.Fprint(w, `{"users":[],"teams":[]}`)
+			_, _ = fmt.Fprint(w, `{"users":[],"teams":[]}`)
 		case strings.Contains(r.URL.Path, "/reviews") && r.Method == http.MethodGet:
-			fmt.Fprintf(w, `[{"id":1,"user":{"login":"copilot-pull-request-reviewer[bot]"},"state":"APPROVED","submitted_at":%q}]`,
+			_, _ = fmt.Fprintf(w, `[{"id":1,"user":{"login":"copilot-pull-request-reviewer[bot]"},"state":"APPROVED","submitted_at":%q}]`,
 				submittedAt.UTC().Format(time.RFC3339))
 		default:
 			// GraphQL: distinguish node-ID query from requestReviewsByLogin mutation by
@@ -43,9 +43,9 @@ func newGitHubAPIMock(t *testing.T, submittedAt time.Time) *httptest.Server {
 			// The mutation body always contains "requestReviewsByLogin" as the operation.
 			body, _ := io.ReadAll(r.Body)
 			if strings.Contains(string(body), "requestReviewsByLogin") {
-				fmt.Fprint(w, `{"data":{"requestReviewsByLogin":{"clientMutationId":""}}}`)
+				_, _ = fmt.Fprint(w, `{"data":{"requestReviewsByLogin":{"clientMutationId":""}}}`)
 			} else {
-				fmt.Fprint(w, `{"data":{"repository":{"pullRequest":{"id":"PR_test123"}}}}`)
+				_, _ = fmt.Fprint(w, `{"data":{"repository":{"pullRequest":{"id":"PR_test123"}}}}`)
 			}
 		}
 	}))

--- a/internal/tools/server_test.go
+++ b/internal/tools/server_test.go
@@ -103,18 +103,18 @@ func TestStreamableHandlerRejectsSessionUserMismatch(t *testing.T) {
 	resp := postMCP(t, httpServer.URL, "token-a", "", initBody)
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		t.Fatalf("initialize status = %d, want 200; body=%s", resp.StatusCode, string(body))
 	}
 	sessionID := resp.Header.Get(mcpSessionIDHeader)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if sessionID == "" {
 		t.Fatal("initialize response missing Mcp-Session-Id")
 	}
 
 	initializedBody := []byte(`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`)
 	resp = postMCP(t, httpServer.URL, "token-b", sessionID, initializedBody)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusForbidden {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("mismatched session status = %d, want 403; body=%s", resp.StatusCode, string(body))

--- a/internal/tools/watch_test.go
+++ b/internal/tools/watch_test.go
@@ -356,14 +356,14 @@ func TestWatchResourceHandlerScopesWatchIDByLogin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("srv.Connect() error = %v", err)
 	}
-	defer ss.Wait()
+	defer func() { _ = ss.Wait() }()
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
 	cs, err := client.Connect(context.Background(), ct, nil)
 	if err != nil {
 		t.Fatalf("client.Connect() error = %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	// Bob should not be able to read Alice's watch resource.
 	_, err = cs.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: uri})
@@ -422,14 +422,14 @@ func TestWatchResourceHandlerReturnsJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("srv.Connect() error = %v", err)
 	}
-	defer ss.Wait()
+	defer func() { _ = ss.Wait() }()
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
 	cs, err := client.Connect(context.Background(), ct, nil)
 	if err != nil {
 		t.Fatalf("client.Connect() error = %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	// Alice reads her own watch resource.
 	result, err := cs.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: uri})

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -1101,10 +1101,7 @@ func IsRateLimitHTTPError(err error) bool {
 		return true
 	}
 	var abuseErr *github.AbuseRateLimitError
-	if errors.As(err, &abuseErr) {
-		return true
-	}
-	return false
+	return errors.As(err, &abuseErr)
 }
 
 // reviewStatusChanged reports whether the review status has changed between prev and curr.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,16 @@
+pre-commit:
+  parallel: true
+  commands:
+    vet:
+      run: go vet ./...
+
+pre-push:
+  parallel: true
+  commands:
+    lint:
+      run: golangci-lint run ./...
+    test:
+      run: go test ./...
+      # -race requires CGO (unavailable on Windows); CI runs with -race on Linux
+    build:
+      run: go build ./cmd/server


### PR DESCRIPTION
## Summary

Fixes #33.

`ErrGatewayUpstreamFailure` previously collapsed both gateway 502 error codes because `Token()` drained ALL non-200 response bodies before the switch statement. By the time `case http.StatusBadGateway:` ran, the body was already discarded.

## Root Cause

In `gateway_token_source.go`, lines before the switch called `io.Copy(io.Discard, ...)` for ALL non-200 status codes. The 502 body with `{"error":"rotation_failed"}` or `{"error":"upstream_failure"}` was gone before it could be parsed.

## Fix

- Remove the blanket pre-switch drain.
- Add per-case drains for 401 / 403 / 404 / default (HTTP connection reuse preserved).
- For 502: parse the JSON error body BEFORE draining:
  - `rotation_failed` → new `ErrGatewayRotationFailed` (NOT transient; must re-auth)
  - `upstream_failure` or unknown body → `ErrGatewayUpstreamFailure` (retryable)

## New Sentinel

`ErrGatewayRotationFailed` signals that the GitHub OAuth provider explicitly rejected refresh token rotation. Unlike `ErrGatewayUpstreamFailure`, retrying will not help; the user must re-authenticate.

## Tests

`TestGatewayTokenSource_ErrorMappings` expanded from 1 body-blind 502 case to 3 body-aware cases: `rotation_failed`, `upstream_failure`, and unknown body fallback.

## Also Included

### chore: configure lefthook

Introduces `lefthook.yml` with:
- **pre-commit**: `go vet ./...`
- **pre-push**: `golangci-lint run ./...` + `go test ./...` + `go build ./cmd/server`

### fix(lint): address pre-existing errcheck and staticcheck violations

Fixes 22+ pre-existing lint errors surfaced by the new golangci-lint hook. None of these are regressions introduced by this PR — all were pre-existing.

- **errcheck**: `_, _ =` prefix on unchecked `fmt.Fprint/Fprintf` returns in test HTTP handlers
- **errcheck**: `_ = db.Close()` / `defer func() { _ = rows.Close() }()` on error-path cleanup calls
- **errcheck**: `defer func() { _ = cs.Close() }()` / `defer func() { _ = ss.Wait() }()` in test teardown
- **staticcheck S1008**: simplify boolean return in `IsRateLimitHTTPError`
- **staticcheck QF1001**: extract De Morgan negation to named bool in timeout assertion

All three commits pass the pre-push hook clean: lint=0 issues, tests=green, build=clean.
