### PR TITLE
fix(github): add gateway sentinel mappings to ClassifyGitHubError (#32)

### DIFF
--- a/internal/github/classify.go
+++ b/internal/github/classify.go
@@ -1,0 +1,108 @@
+package ghclient
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-github/v85/github"
+
+	"github.com/scottlz0310/copilot-review-mcp/internal/autherr"
+)
+
+// ClassifyGitHubError maps a GitHub API or gateway error to a structured *autherr.AuthError.
+// Returns nil when the error is not a recognized error type (e.g. context.Canceled).
+//
+// Detection order (most-specific first):
+//  1. *autherr.AuthError — already classified upstream; returned as-is.
+//  2. Gateway sentinel errors — ErrGateway* from gatewayTokenSource.Token().
+//  3. *github.RateLimitError — primary rate limit; retryable, safe to continue after reset.
+//  4. *github.AbuseRateLimitError — secondary / abuse rate limit; not retryable.
+//  5. *github.ErrorResponse — classified by HTTP status code.
+//  6. String-based fallback for shurcooL/githubv4 plain errors.
+func ClassifyGitHubError(err error) *autherr.AuthError {
+	if err == nil {
+		return nil
+	}
+
+	// Already classified.
+	if ae, ok := autherr.AsAuthError(err); ok {
+		return ae
+	}
+
+	// Gateway sentinel errors from gatewayTokenSource.Token().
+	// Checked before generic HTTP-status checks because sentinels carry more
+	// precise semantics than a plain HTTP status code would.
+	switch {
+	case errors.Is(err, ErrGatewayRotationFailed):
+		// Refresh token rotation rejected by GitHub OAuth provider; must re-auth.
+		return autherr.NewTokenRefreshFailed()
+	case errors.Is(err, ErrGatewaySubjectGone):
+		// GitHub removed or revoked the subject; re-authentication is required.
+		return autherr.NewReauthRequired()
+	case errors.Is(err, ErrGatewayUpstreamFailure):
+		// Transient resolver or upstream failure; retry may succeed.
+		return autherr.NewTransientUpstreamError()
+	case errors.Is(err, ErrGatewayUnauthorized):
+		// Shared-secret misconfiguration; no usable token is available.
+		return autherr.NewAuthRequired()
+	case errors.Is(err, ErrGatewayLoopbackRequired):
+		// Gateway endpoint is not on loopback; configuration error.
+		return autherr.NewAuthRequired()
+	case errors.Is(err, ErrGatewayBadRequest):
+		// Request arguments rejected by the gateway; caller should not retry.
+		return autherr.NewValidationError()
+	}
+
+	// Primary rate limit (go-github wraps 403 + X-RateLimit-Remaining: 0).
+	var rateLimitErr *github.RateLimitError
+	if errors.As(err, &rateLimitErr) {
+		return autherr.NewRateLimited(true, true)
+	}
+
+	// Secondary / abuse rate limit (go-github wraps 403 + abuse message).
+	var abuseErr *github.AbuseRateLimitError
+	if errors.As(err, &abuseErr) {
+		return autherr.NewRateLimited(false, false)
+	}
+
+	// REST API errors with explicit HTTP status codes.
+	var ghErr *github.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Response != nil {
+		switch ghErr.Response.StatusCode {
+		case http.StatusUnauthorized:
+			return autherr.NewReauthRequired()
+		case http.StatusForbidden:
+			return autherr.NewPermissionDenied()
+		case http.StatusNotFound:
+			return autherr.NewNotFound()
+		case http.StatusBadRequest, http.StatusUnprocessableEntity:
+			return autherr.NewValidationError()
+		case http.StatusInternalServerError,
+			http.StatusBadGateway,
+			http.StatusServiceUnavailable,
+			http.StatusGatewayTimeout:
+			return autherr.NewTransientUpstreamError()
+		}
+	}
+
+	// shurcooL/githubv4 plain-error fallbacks (string-based).
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "401 Unauthorized"):
+		return autherr.NewReauthRequired()
+	case strings.Contains(msg, "403 Forbidden"):
+		return autherr.NewPermissionDenied()
+	case strings.Contains(msg, "404 Not Found"):
+		return autherr.NewNotFound()
+	case strings.Contains(msg, "422 Unprocessable"), strings.Contains(msg, "400 Bad Request"):
+		return autherr.NewValidationError()
+	case strings.Contains(msg, "500 Internal Server Error"),
+		strings.Contains(msg, "502 Bad Gateway"),
+		strings.Contains(msg, "503 Service Unavailable"),
+		strings.Contains(msg, "504 Gateway Timeout"):
+		return autherr.NewTransientUpstreamError()
+	}
+
+	return nil
+}

--- a/internal/github/classify_test.go
+++ b/internal/github/classify_test.go
@@ -147,6 +147,34 @@ func TestClassifyGitHubError_GraphQLStrings(t *testing.T) {
 	}
 }
 
+func TestClassifyGitHubError_GatewaySentinels(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantType autherr.AuthErrorType
+	}{
+		{"ErrGatewayRotationFailed", ghclient.ErrGatewayRotationFailed, autherr.TOKEN_REFRESH_FAILED},
+		{"ErrGatewaySubjectGone", ghclient.ErrGatewaySubjectGone, autherr.REAUTH_REQUIRED},
+		{"ErrGatewayUpstreamFailure", ghclient.ErrGatewayUpstreamFailure, autherr.TRANSIENT_UPSTREAM_ERROR},
+		{"ErrGatewayUnauthorized", ghclient.ErrGatewayUnauthorized, autherr.AUTH_REQUIRED},
+		{"ErrGatewayLoopbackRequired", ghclient.ErrGatewayLoopbackRequired, autherr.AUTH_REQUIRED},
+		{"ErrGatewayBadRequest", ghclient.ErrGatewayBadRequest, autherr.VALIDATION_ERROR},
+		{"wrapped ErrGatewayRotationFailed", fmt.Errorf("outer: %w", ghclient.ErrGatewayRotationFailed), autherr.TOKEN_REFRESH_FAILED},
+		{"wrapped ErrGatewayUpstreamFailure", fmt.Errorf("outer: %w", ghclient.ErrGatewayUpstreamFailure), autherr.TRANSIENT_UPSTREAM_ERROR},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ghclient.ClassifyGitHubError(tc.err)
+			if got == nil {
+				t.Fatalf("ClassifyGitHubError(%v) = nil, want %q", tc.err, tc.wantType)
+			}
+			if got.ErrorType != tc.wantType {
+				t.Errorf("ErrorType = %q, want %q", got.ErrorType, tc.wantType)
+			}
+		})
+	}
+}
+
 func TestClassifyGitHubError_UnknownError(t *testing.T) {
 	got := ghclient.ClassifyGitHubError(fmt.Errorf("something completely different"))
 	if got != nil {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -14,8 +14,6 @@ import (
 	"github.com/google/go-github/v85/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
-
-	"github.com/scottlz0310/copilot-review-mcp/internal/autherr"
 )
 
 // invalidatingTransport wraps an HTTP transport and calls invalidate(token) when
@@ -342,78 +340,6 @@ func IsAuthError(err error) bool {
 	// shurcooL/githubv4 returns a plain error with the message
 	// "non-200 OK status code: 401 Unauthorized body: ..." for HTTP 401.
 	return strings.Contains(err.Error(), "401 Unauthorized")
-}
-
-// ClassifyGitHubError maps a GitHub API error to a structured *autherr.AuthError.
-// Returns nil when the error is not a recognized GitHub API error (e.g. context.Canceled).
-//
-// Detection order (most-specific first):
-//  1. *autherr.AuthError — already classified upstream; returned as-is.
-//  2. *github.RateLimitError — primary rate limit; retryable, safe to continue after reset.
-//  3. *github.AbuseRateLimitError — secondary / abuse rate limit; not retryable.
-//  4. *github.ErrorResponse — classified by HTTP status code.
-//  5. String-based fallback for shurcooL/githubv4 plain errors.
-func ClassifyGitHubError(err error) *autherr.AuthError {
-	if err == nil {
-		return nil
-	}
-
-	// Already classified.
-	if ae, ok := autherr.AsAuthError(err); ok {
-		return ae
-	}
-
-	// Primary rate limit (go-github wraps 403 + X-RateLimit-Remaining: 0).
-	var rateLimitErr *github.RateLimitError
-	if errors.As(err, &rateLimitErr) {
-		return autherr.NewRateLimited(true, true)
-	}
-
-	// Secondary / abuse rate limit (go-github wraps 403 + abuse message).
-	var abuseErr *github.AbuseRateLimitError
-	if errors.As(err, &abuseErr) {
-		return autherr.NewRateLimited(false, false)
-	}
-
-	// REST API errors with explicit HTTP status codes.
-	var ghErr *github.ErrorResponse
-	if errors.As(err, &ghErr) && ghErr.Response != nil {
-		switch ghErr.Response.StatusCode {
-		case http.StatusUnauthorized:
-			return autherr.NewReauthRequired()
-		case http.StatusForbidden:
-			return autherr.NewPermissionDenied()
-		case http.StatusNotFound:
-			return autherr.NewNotFound()
-		case http.StatusBadRequest, http.StatusUnprocessableEntity:
-			return autherr.NewValidationError()
-		case http.StatusInternalServerError,
-			http.StatusBadGateway,
-			http.StatusServiceUnavailable,
-			http.StatusGatewayTimeout:
-			return autherr.NewTransientUpstreamError()
-		}
-	}
-
-	// shurcooL/githubv4 plain-error fallbacks (string-based).
-	msg := err.Error()
-	switch {
-	case strings.Contains(msg, "401 Unauthorized"):
-		return autherr.NewReauthRequired()
-	case strings.Contains(msg, "403 Forbidden"):
-		return autherr.NewPermissionDenied()
-	case strings.Contains(msg, "404 Not Found"):
-		return autherr.NewNotFound()
-	case strings.Contains(msg, "422 Unprocessable"), strings.Contains(msg, "400 Bad Request"):
-		return autherr.NewValidationError()
-	case strings.Contains(msg, "500 Internal Server Error"),
-		strings.Contains(msg, "502 Bad Gateway"),
-		strings.Contains(msg, "503 Service Unavailable"),
-		strings.Contains(msg, "504 Gateway Timeout"):
-		return autherr.NewTransientUpstreamError()
-	}
-
-	return nil
 }
 
 // prNodeIDQuery fetches the GraphQL node ID for a pull request.


### PR DESCRIPTION
## Summary

Closes #32

`ClassifyGitHubError` had no handling for the `ErrGateway*` sentinel errors returned by `gatewayTokenSource.Token()`. As a result, tool calls failing with gateway errors fell through to `nil`, giving MCP clients no actionable guidance.

## Changes

### New file: `internal/github/classify.go`
- Extracted `ClassifyGitHubError` from `client.go` (where it lived alongside unrelated transport code) into a dedicated file matching the existing `classify_test.go`
- Added `errors.Is` checks for all gateway sentinel errors **before** the generic HTTP-status checks, so sentinels' precise semantics are preserved even when wrapped

### Mapping added

| Sentinel | AuthErrorType | Rationale |
|---|---|---|
| `ErrGatewayRotationFailed` | `TOKEN_REFRESH_FAILED` | Refresh token rotation rejected; user must re-auth |
| `ErrGatewaySubjectGone` | `REAUTH_REQUIRED` | Subject revoked by GitHub; re-auth required |
| `ErrGatewayUpstreamFailure` | `TRANSIENT_UPSTREAM_ERROR` | Transient resolver failure; retry may succeed |
| `ErrGatewayUnauthorized` | `AUTH_REQUIRED` | Shared-secret misconfiguration |
| `ErrGatewayLoopbackRequired` | `AUTH_REQUIRED` | Endpoint not on loopback; config error |
| `ErrGatewayBadRequest` | `VALIDATION_ERROR` | Bad request from gateway; config error |

### Updated: `internal/github/classify_test.go`
- Added `TestClassifyGitHubError_GatewaySentinels`: 8 cases covering all 6 sentinels plus two wrapped-error cases

### Updated: `internal/github/client.go`
- Removed `ClassifyGitHubError` and the now-unused `autherr` import

## Notes
- `ErrGatewayRotationFailed` was introduced in #33 (PR #34, merged to main). This PR depends on that sentinel being present.
- Wrapped errors work correctly: `errors.Is` unwraps before comparing sentinels.
