### PR TITLE
fix(watch): map ErrGatewaySubjectGone and ErrGatewayRotationFailed to FailureReasonAuthExpired (#31)

### DIFF
--- a/internal/github/auth_error_test.go
+++ b/internal/github/auth_error_test.go
@@ -2,6 +2,7 @@ package ghclient
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -54,6 +55,37 @@ func TestIsAuthError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsAuthError(tt.err); got != tt.want {
 				t.Fatalf("IsAuthError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsGatewayAuthError(t *testing.T) {
+	wrapped := func(sentinel error) error {
+		return fmt.Errorf("outer: %w", sentinel)
+	}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"ErrGatewaySubjectGone direct", ErrGatewaySubjectGone, true},
+		{"ErrGatewayRotationFailed direct", ErrGatewayRotationFailed, true},
+		{"ErrGatewaySubjectGone wrapped", wrapped(ErrGatewaySubjectGone), true},
+		{"ErrGatewayRotationFailed wrapped", wrapped(ErrGatewayRotationFailed), true},
+		// ErrGatewayUpstreamFailure is transient; must NOT map to auth error.
+		{"ErrGatewayUpstreamFailure direct", ErrGatewayUpstreamFailure, false},
+		{"ErrGatewayUpstreamFailure wrapped", wrapped(ErrGatewayUpstreamFailure), false},
+		{"ErrGatewayUnauthorized", ErrGatewayUnauthorized, false},
+		{"ErrGatewayBadRequest", ErrGatewayBadRequest, false},
+		{"unrelated error", errors.New("network timeout"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsGatewayAuthError(tt.err); got != tt.want {
+				t.Fatalf("IsGatewayAuthError() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -342,6 +342,19 @@ func IsAuthError(err error) bool {
 	return strings.Contains(err.Error(), "401 Unauthorized")
 }
 
+// IsGatewayAuthError reports whether err is a gateway sentinel that requires
+// the user to re-authenticate. It returns true for:
+//   - ErrGatewaySubjectGone: the gateway has no cached token record for the
+//     subject; the user must issue a fresh client request to re-seed the cache.
+//   - ErrGatewayRotationFailed: the gateway tried to rotate the refresh token
+//     but GitHub explicitly rejected it; the user must re-authenticate.
+//
+// ErrGatewayUpstreamFailure is intentionally excluded: it is a transient
+// upstream failure that may resolve on retry and does not require user action.
+func IsGatewayAuthError(err error) bool {
+	return errors.Is(err, ErrGatewaySubjectGone) || errors.Is(err, ErrGatewayRotationFailed)
+}
+
 // prNodeIDQuery fetches the GraphQL node ID for a pull request.
 // Used by RequestCopilotReview to obtain the ID required by the mutation.
 type prNodeIDQuery struct {

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -680,7 +680,7 @@ func (m *Manager) pollOnce(watchID string) bool {
 			return true
 		}
 		reason := FailureReasonGitHubError
-		if ghclient.IsAuthError(err) {
+		if ghclient.IsAuthError(err) || ghclient.IsGatewayAuthError(err) {
 			reason = FailureReasonAuthExpired
 		}
 		m.finishFailureWithPoll(w.id, now, reason, err.Error())

--- a/internal/watch/manager_test.go
+++ b/internal/watch/manager_test.go
@@ -298,6 +298,94 @@ func TestManagerAuthExpiredFailsWatch(t *testing.T) {
 	}
 }
 
+func TestManagerGatewayAuthExpiredFailsWatch(t *testing.T) {
+	sentinels := []struct {
+		name string
+		err  error
+	}{
+		{"ErrGatewaySubjectGone", ghclient.ErrGatewaySubjectGone},
+		{"ErrGatewayRotationFailed", ghclient.ErrGatewayRotationFailed},
+	}
+
+	for i, tc := range sentinels {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t)
+			manager := NewManager(db, Options{
+				PollInterval: 5 * time.Millisecond,
+				Threshold:    30 * time.Second,
+				ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
+					return &fakeFetcher{
+						results: []fetchResult{
+							{err: tc.err},
+						},
+					}
+				},
+			})
+			t.Cleanup(manager.Close)
+
+			started, _, err := manager.Start(StartInput{
+				Login: "alice",
+				Token: "some-token",
+				Owner: "octo",
+				Repo:  "demo",
+				PR:    900 + i,
+			})
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+
+			snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+				return s.Terminal
+			})
+			if snapshot.WatchStatus != StatusFailed {
+				t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusFailed)
+			}
+			if snapshot.FailureReason == nil || *snapshot.FailureReason != FailureReasonAuthExpired {
+				t.Fatalf("FailureReason = %v, want %q", snapshot.FailureReason, FailureReasonAuthExpired)
+			}
+		})
+	}
+}
+
+func TestManagerGatewayUpstreamFailureIsNotAuthExpired(t *testing.T) {
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval: 5 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{err: ghclient.ErrGatewayUpstreamFailure},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "some-token",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    901,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus != StatusFailed {
+		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusFailed)
+	}
+	if snapshot.FailureReason == nil || *snapshot.FailureReason != FailureReasonGitHubError {
+		t.Fatalf("FailureReason = %v, want %q (ErrGatewayUpstreamFailure must not become AUTH_EXPIRED)",
+			snapshot.FailureReason, FailureReasonGitHubError)
+	}
+}
+
 func TestManagerCloseMarksActiveWatchStale(t *testing.T) {
 	db := openTestDB(t)
 	manager := NewManager(db, Options{


### PR DESCRIPTION
## Summary
Closes #31

Gateway sentinel errors (`ErrGatewaySubjectGone`, `ErrGatewayRotationFailed`) were classified as `FailureReasonGitHubError` instead of `FailureReasonAuthExpired` in the watch manager, because `IsAuthError` only detects GitHub API HTTP 401 responses and does not know about the gateway sentinel layer.

As a result, watches that failed due to a gone subject or a rejected token rotation would tell the user "GitHub error" rather than "re-authentication required", and the watch would keep retrying until timeout.

## Changes

### `internal/github/client.go` — new predicate `IsGatewayAuthError`

```go
func IsGatewayAuthError(err error) bool {
    return errors.Is(err, ErrGatewaySubjectGone) || errors.Is(err, ErrGatewayRotationFailed)
}
```

Returns `true` for the two permanent gateway auth failures:

| Sentinel | Meaning |
|---|---|
| `ErrGatewaySubjectGone` | Gateway has no cached token record for the subject (HTTP 404); user must re-seed |
| `ErrGatewayRotationFailed` | GitHub rejected refresh token rotation (502/rotation_failed); user must re-auth |

`ErrGatewayUpstreamFailure` is intentionally **excluded**. Since PR #34 introduced JSON body parsing for HTTP 502 responses, this sentinel now represents only the `upstream_failure` code (or unrecognised 502 bodies) and is genuinely transient/retryable. It is correctly left as `FailureReasonGitHubError`. See #37 for a follow-up to add retry-escalation logic for persistent upstream failures.

### `internal/watch/manager.go` — poll-error handler

```go
// before
if ghclient.IsAuthError(err) {
// after
if ghclient.IsAuthError(err) || ghclient.IsGatewayAuthError(err) {
```

### `internal/github/auth_error_test.go` — `TestIsGatewayAuthError`

10 cases: direct and wrapped sentinels for both auth-mapping sentinels, negative cases for `ErrGatewayUpstreamFailure` (direct and wrapped), `ErrGatewayUnauthorized`, `ErrGatewayBadRequest`, and unrelated errors.

### `internal/watch/manager_test.go` — two new tests

- `TestManagerGatewayAuthExpiredFailsWatch`: confirms `ErrGatewaySubjectGone` and `ErrGatewayRotationFailed` both produce `FailureReasonAuthExpired`
- `TestManagerGatewayUpstreamFailureIsNotAuthExpired`: regression guard confirming `ErrGatewayUpstreamFailure` remains `FailureReasonGitHubError`

## Notes

This is the companion fix to #32 (gateway sentinel mappings in `ClassifyGitHubError`). Together they complete the end-to-end gateway error propagation: sentinels are now classified correctly both in the auth error classifier and in the watch failure reason logic.

`lefthook` pre-push hook: lint ✅ · tests ✅ · build ✅
