### PR TITLE
fix(watch): escalate ErrGatewayUpstreamFailure to AUTH_EXPIRED after N consecutive failures

### DIFF
--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -22,6 +22,7 @@ var ErrManagerClosed = errors.New("watch manager is closed")
 const defaultPollInterval = 90 * time.Second
 const defaultPollTimeout = 30 * time.Second
 const defaultMaxWatchDuration = 2 * time.Hour
+const defaultUpstreamFailureThreshold = 5
 
 // Status is the lifecycle state of a background review watch.
 type Status string
@@ -97,6 +98,9 @@ type Options struct {
 	// (e.g. "copilot-review://watch/{id}"). It is safe to call srv.ResourceUpdated
 	// from this callback.
 	NotifyResourceUpdated func(uri string)
+	// UpstreamFailureThreshold is the number of consecutive ErrGatewayUpstreamFailure
+	// errors before the watch is escalated to FailureReasonAuthExpired. Defaults to 5.
+	UpstreamFailureThreshold int
 }
 
 // CancelResult reports the outcome of a manual watch cancellation request.
@@ -126,22 +130,23 @@ type watchStore interface {
 
 // Manager owns background review-watch workers for the current server process.
 type Manager struct {
-	db                    watchStore
-	threshold             time.Duration
-	pollInterval          time.Duration
-	pollTimeout           time.Duration
-	maxWatchDuration      time.Duration
-	notifyResourceUpdated func(uri string)
-	clientFactory         func(ctx context.Context, token, login string) ReviewDataFetcher
-	now                   func() time.Time
-	ctx                   context.Context
-	cancel                context.CancelFunc
-	idSeq                 atomic.Uint64
-	mu                    sync.RWMutex
-	watchesByID           map[string]*watchState
-	activeByKey           map[watchKey]string
-	latestByKey           map[watchKey]string
-	closed                bool
+	db                       watchStore
+	threshold                time.Duration
+	pollInterval             time.Duration
+	pollTimeout              time.Duration
+	maxWatchDuration         time.Duration
+	upstreamFailureThreshold int
+	notifyResourceUpdated    func(uri string)
+	clientFactory            func(ctx context.Context, token, login string) ReviewDataFetcher
+	now                      func() time.Time
+	ctx                      context.Context
+	cancel                   context.CancelFunc
+	idSeq                    atomic.Uint64
+	mu                       sync.RWMutex
+	watchesByID              map[string]*watchState
+	activeByKey              map[watchKey]string
+	latestByKey              map[watchKey]string
+	closed                   bool
 }
 
 type watchKey struct {
@@ -152,28 +157,29 @@ type watchKey struct {
 }
 
 type watchState struct {
-	id               string
-	key              watchKey
-	triggerLogID     *int64
-	resourceURI      *string
-	token            string
-	ctx              context.Context
-	cancel           context.CancelFunc
-	clientMu         sync.RWMutex
-	client           ReviewDataFetcher
-	status           Status
-	reviewStatus     *ghclient.ReviewStatus
-	failureReason    *FailureReason
-	terminal         bool
-	workerRunning    bool
-	pollsDone        int
-	startedAt        time.Time
-	updatedAt        time.Time
-	completedAt      *time.Time
-	staleAt          *time.Time
-	lastPolledAt     *time.Time
-	lastError        *string
-	rateLimitResetAt *time.Time
+	id                   string
+	key                  watchKey
+	triggerLogID         *int64
+	resourceURI          *string
+	token                string
+	ctx                  context.Context
+	cancel               context.CancelFunc
+	clientMu             sync.RWMutex
+	client               ReviewDataFetcher
+	status               Status
+	reviewStatus         *ghclient.ReviewStatus
+	failureReason        *FailureReason
+	terminal             bool
+	workerRunning        bool
+	pollsDone            int
+	startedAt            time.Time
+	updatedAt            time.Time
+	completedAt          *time.Time
+	staleAt              *time.Time
+	lastPolledAt         *time.Time
+	lastError            *string
+	rateLimitResetAt     *time.Time
+	upstreamFailureCount int
 }
 
 // NewManager creates a process-local, memory-only watch manager.
@@ -190,6 +196,10 @@ func NewManager(db watchStore, opts Options) *Manager {
 	if maxWatchDuration <= 0 {
 		maxWatchDuration = defaultMaxWatchDuration
 	}
+	upstreamFailureThreshold := opts.UpstreamFailureThreshold
+	if upstreamFailureThreshold <= 0 {
+		upstreamFailureThreshold = defaultUpstreamFailureThreshold
+	}
 	now := opts.Now
 	if now == nil {
 		now = time.Now
@@ -202,19 +212,20 @@ func NewManager(db watchStore, opts Options) *Manager {
 		}
 	}
 	return &Manager{
-		db:                    db,
-		threshold:             opts.Threshold,
-		pollInterval:          pollInterval,
-		pollTimeout:           pollTimeout,
-		maxWatchDuration:      maxWatchDuration,
-		notifyResourceUpdated: opts.NotifyResourceUpdated,
-		clientFactory:         clientFactory,
-		now:                   now,
-		ctx:                   ctx,
-		cancel:                cancel,
-		watchesByID:           make(map[string]*watchState),
-		activeByKey:           make(map[watchKey]string),
-		latestByKey:           make(map[watchKey]string),
+		db:                       db,
+		threshold:                opts.Threshold,
+		pollInterval:             pollInterval,
+		pollTimeout:              pollTimeout,
+		maxWatchDuration:         maxWatchDuration,
+		upstreamFailureThreshold: upstreamFailureThreshold,
+		notifyResourceUpdated:    opts.NotifyResourceUpdated,
+		clientFactory:            clientFactory,
+		now:                      now,
+		ctx:                      ctx,
+		cancel:                   cancel,
+		watchesByID:              make(map[string]*watchState),
+		activeByKey:              make(map[watchKey]string),
+		latestByKey:              make(map[watchKey]string),
 	}
 }
 
@@ -679,6 +690,9 @@ func (m *Manager) pollOnce(watchID string) bool {
 			m.finishStatusWithPoll(w.id, now, StatusRateLimited, nil, err.Error())
 			return true
 		}
+		if errors.Is(err, ghclient.ErrGatewayUpstreamFailure) {
+			return m.handleUpstreamFailure(w.id, now, err.Error())
+		}
 		reason := FailureReasonGitHubError
 		if ghclient.IsAuthError(err) || ghclient.IsGatewayAuthError(err) {
 			reason = FailureReasonAuthExpired
@@ -762,6 +776,7 @@ func (m *Manager) pollOnce(watchID string) bool {
 	m.markPollLocked(current, now)
 	current.reviewStatus = reviewStatusPtr(reviewStatus)
 	current.lastError = nil
+	current.upstreamFailureCount = 0
 	current.rateLimitResetAt = nil
 	if current.triggerLogID == nil && entry != nil {
 		id := entry.ID
@@ -809,6 +824,46 @@ func (m *Manager) finishStatusWithPoll(watchID string, now time.Time, status Sta
 
 func (m *Manager) finishStatusWithoutPoll(watchID string, now time.Time, status Status, reason *FailureReason, errText string) {
 	m.finishState(watchID, now, status, reason, errText, false)
+}
+
+// handleUpstreamFailure counts consecutive ErrGatewayUpstreamFailure errors and
+// escalates to FailureReasonAuthExpired once the configured threshold is reached.
+// Returns true when the poll loop should stop (terminal transition or persist failure),
+// false when the watch should keep running.
+func (m *Manager) handleUpstreamFailure(watchID string, now time.Time, errText string) bool {
+	m.mu.Lock()
+	w := m.watchesByID[watchID]
+	if w == nil || w.terminal {
+		m.mu.Unlock()
+		return true
+	}
+	w.upstreamFailureCount++
+	if w.upstreamFailureCount >= m.upstreamFailureThreshold {
+		count := w.upstreamFailureCount
+		msg := fmt.Sprintf("gateway upstream_failure persisted after %d consecutive failures; re-authenticate: %s", count, errText)
+		reason := FailureReasonAuthExpired
+		m.markPollLocked(w, now)
+		m.finishLocked(w, StatusFailed, &reason, now, msg)
+		m.mu.Unlock()
+		return true
+	}
+	// Below threshold: record the transient error and keep watching.
+	m.markPollLocked(w, now)
+	errCopy := errText
+	w.lastError = &errCopy
+	if err := m.persistOrDegradeLocked(w, StatusWatching, now); err != nil {
+		var notifyURI string
+		if m.notifyResourceUpdated != nil && w.resourceURI != nil {
+			notifyURI = *w.resourceURI
+		}
+		m.mu.Unlock()
+		if notifyURI != "" {
+			go m.notifyResourceUpdated(notifyURI)
+		}
+		return true
+	}
+	m.mu.Unlock()
+	return false
 }
 
 func (m *Manager) finishState(watchID string, now time.Time, status Status, reason *FailureReason, errText string, countedPoll bool) {

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -313,6 +313,9 @@ func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 				existing.clientMu.Lock()
 				existing.client = m.clientFactory(existing.ctx, in.Token, key.login)
 				existing.clientMu.Unlock()
+				// New credentials start a fresh upstream-failure budget.
+				existing.upstreamFailureCount = 0
+				existing.lastError = nil
 			}
 			if triggerLinked {
 				existing.triggerLogID = cloneInt64Ptr(triggerLogID)

--- a/internal/watch/manager_test.go
+++ b/internal/watch/manager_test.go
@@ -349,14 +349,24 @@ func TestManagerGatewayAuthExpiredFailsWatch(t *testing.T) {
 }
 
 func TestManagerGatewayUpstreamFailureIsNotAuthExpired(t *testing.T) {
+	// N-1 consecutive upstream failures followed by a success must NOT escalate
+	// to AUTH_EXPIRED. The watch should complete normally after the success.
+	const threshold = 3
+	reviewTime := time.Now().Add(time.Minute)
 	db := openTestDB(t)
 	manager := NewManager(db, Options{
-		PollInterval: 5 * time.Millisecond,
-		Threshold:    30 * time.Second,
+		PollInterval:             5 * time.Millisecond,
+		Threshold:                30 * time.Second,
+		UpstreamFailureThreshold: threshold,
 		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
 					{err: ghclient.ErrGatewayUpstreamFailure},
+					{err: ghclient.ErrGatewayUpstreamFailure},
+					{data: &ghclient.ReviewData{
+						LatestCopilotReview: newReview("APPROVED", &reviewTime),
+						RateLimitRemaining:  100,
+					}},
 				},
 			}
 		},
@@ -377,12 +387,106 @@ func TestManagerGatewayUpstreamFailureIsNotAuthExpired(t *testing.T) {
 	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
 		return s.Terminal
 	})
+	if snapshot.WatchStatus == StatusFailed && snapshot.FailureReason != nil && *snapshot.FailureReason == FailureReasonAuthExpired {
+		t.Fatalf("WatchStatus = %q FailureReason = %q: below-threshold upstream failures must not escalate to AUTH_EXPIRED",
+			snapshot.WatchStatus, *snapshot.FailureReason)
+	}
+}
+
+func TestManagerGatewayUpstreamFailureEscalatesAfterThreshold(t *testing.T) {
+	// Exactly <threshold> consecutive ErrGatewayUpstreamFailure errors must
+	// escalate the watch to FAILED/AUTH_EXPIRED.
+	const threshold = 3
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval:             5 * time.Millisecond,
+		Threshold:                30 * time.Second,
+		UpstreamFailureThreshold: threshold,
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					{err: ghclient.ErrGatewayUpstreamFailure},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "some-token",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    902,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
 	if snapshot.WatchStatus != StatusFailed {
 		t.Fatalf("WatchStatus = %q, want %q", snapshot.WatchStatus, StatusFailed)
 	}
-	if snapshot.FailureReason == nil || *snapshot.FailureReason != FailureReasonGitHubError {
-		t.Fatalf("FailureReason = %v, want %q (ErrGatewayUpstreamFailure must not become AUTH_EXPIRED)",
-			snapshot.FailureReason, FailureReasonGitHubError)
+	if snapshot.FailureReason == nil || *snapshot.FailureReason != FailureReasonAuthExpired {
+		t.Fatalf("FailureReason = %v, want %q after %d consecutive upstream failures",
+			snapshot.FailureReason, FailureReasonAuthExpired, threshold)
+	}
+	if snapshot.LastError == nil || !strings.Contains(*snapshot.LastError, "consecutive failures") {
+		t.Fatalf("LastError = %v, want message containing \"consecutive failures\"", snapshot.LastError)
+	}
+}
+
+func TestManagerGatewayUpstreamFailureCounterResetsOnSuccess(t *testing.T) {
+	// N-1 upstream failures followed by a success must reset the counter so that
+	// a subsequent run of N-1 failures does not trigger escalation.
+	const threshold = 3
+	reviewTime := time.Now().Add(time.Minute)
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval:             5 * time.Millisecond,
+		Threshold:                30 * time.Second,
+		UpstreamFailureThreshold: threshold,
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
+			return &fakeFetcher{
+				results: []fetchResult{
+					// Two failures (count → 2, below threshold=3)
+					{err: ghclient.ErrGatewayUpstreamFailure},
+					{err: ghclient.ErrGatewayUpstreamFailure},
+					// Success resets counter to 0; review not yet complete
+					{data: &ghclient.ReviewData{IsCopilotInReviewers: true, RateLimitRemaining: 100}},
+					// Two more failures (count → 2 again, still below threshold)
+					{err: ghclient.ErrGatewayUpstreamFailure},
+					{err: ghclient.ErrGatewayUpstreamFailure},
+					// Final success with completed review → COMPLETED
+					{data: &ghclient.ReviewData{
+						LatestCopilotReview: newReview("APPROVED", &reviewTime),
+						RateLimitRemaining:  100,
+					}},
+				},
+			}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "some-token",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    903,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus == StatusFailed && snapshot.FailureReason != nil && *snapshot.FailureReason == FailureReasonAuthExpired {
+		t.Fatalf("WatchStatus = %q FailureReason = %q: counter should have been reset by intermediate success",
+			snapshot.WatchStatus, *snapshot.FailureReason)
 	}
 }
 

--- a/internal/watch/manager_test.go
+++ b/internal/watch/manager_test.go
@@ -387,9 +387,15 @@ func TestManagerGatewayUpstreamFailureIsNotAuthExpired(t *testing.T) {
 	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
 		return s.Terminal
 	})
-	if snapshot.WatchStatus == StatusFailed && snapshot.FailureReason != nil && *snapshot.FailureReason == FailureReasonAuthExpired {
-		t.Fatalf("WatchStatus = %q FailureReason = %q: below-threshold upstream failures must not escalate to AUTH_EXPIRED",
-			snapshot.WatchStatus, *snapshot.FailureReason)
+	if snapshot.WatchStatus != StatusCompleted {
+		t.Fatalf("WatchStatus = %q, want %q: below-threshold upstream failures must not prevent completion",
+			snapshot.WatchStatus, StatusCompleted)
+	}
+	if snapshot.FailureReason != nil {
+		t.Fatalf("FailureReason = %q, want nil", *snapshot.FailureReason)
+	}
+	if snapshot.LastError != nil {
+		t.Fatalf("LastError = %q, want nil after successful completion", *snapshot.LastError)
 	}
 }
 
@@ -484,9 +490,15 @@ func TestManagerGatewayUpstreamFailureCounterResetsOnSuccess(t *testing.T) {
 	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
 		return s.Terminal
 	})
-	if snapshot.WatchStatus == StatusFailed && snapshot.FailureReason != nil && *snapshot.FailureReason == FailureReasonAuthExpired {
-		t.Fatalf("WatchStatus = %q FailureReason = %q: counter should have been reset by intermediate success",
-			snapshot.WatchStatus, *snapshot.FailureReason)
+	if snapshot.WatchStatus != StatusCompleted {
+		t.Fatalf("WatchStatus = %q, want %q: counter reset by intermediate success must allow final completion",
+			snapshot.WatchStatus, StatusCompleted)
+	}
+	if snapshot.FailureReason != nil {
+		t.Fatalf("FailureReason = %q, want nil", *snapshot.FailureReason)
+	}
+	if snapshot.LastError != nil {
+		t.Fatalf("LastError = %q, want nil after successful completion", *snapshot.LastError)
 	}
 }
 

--- a/internal/watch/manager_test.go
+++ b/internal/watch/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -492,6 +493,101 @@ func TestManagerGatewayUpstreamFailureCounterResetsOnSuccess(t *testing.T) {
 	})
 	if snapshot.WatchStatus != StatusCompleted {
 		t.Fatalf("WatchStatus = %q, want %q: counter reset by intermediate success must allow final completion",
+			snapshot.WatchStatus, StatusCompleted)
+	}
+	if snapshot.FailureReason != nil {
+		t.Fatalf("FailureReason = %q, want nil", *snapshot.FailureReason)
+	}
+	if snapshot.LastError != nil {
+		t.Fatalf("LastError = %q, want nil after successful completion", *snapshot.LastError)
+	}
+}
+
+func TestManagerUpstreamFailureCounterResetsOnTokenChange(t *testing.T) {
+	// If a watch has accumulated threshold-1 consecutive upstream failures and
+	// the caller then calls Start() with a new token, the failure counter must be
+	// reset to 0. Without this reset, the very first upstream failure after
+	// re-authentication would immediately escalate to FAILED/AUTH_EXPIRED.
+	const threshold = 3
+	reviewTime := time.Now().Add(time.Minute)
+	db := openTestDB(t)
+
+	// tokenABlocked is closed when the token-a fetcher has fired threshold-1
+	// times and is now blocking, waiting for the main goroutine to swap tokens.
+	tokenABlocked := make(chan struct{})
+	tokenAUnblock := make(chan struct{})
+
+	manager := NewManager(db, Options{
+		PollInterval:             5 * time.Millisecond,
+		Threshold:                30 * time.Second,
+		UpstreamFailureThreshold: threshold,
+		ClientFactory: func(_ context.Context, token, _ string) ReviewDataFetcher {
+			if token != "token-a" {
+				return &fakeFetcher{results: []fetchResult{
+					{data: &ghclient.ReviewData{
+						LatestCopilotReview: newReview("APPROVED", &reviewTime),
+						RateLimitRemaining:  100,
+					}},
+				}}
+			}
+			var callCount int32
+			var once sync.Once
+			return &callbackFetcher{fn: func() (*ghclient.ReviewData, error) {
+				n := atomic.AddInt32(&callCount, 1)
+				if int(n) >= threshold-1 {
+					once.Do(func() { close(tokenABlocked) })
+					// Block until the main goroutine has swapped the token,
+					// preventing any further upstream failures from incrementing
+					// the counter before the reset takes effect.
+					<-tokenAUnblock
+				}
+				return nil, ghclient.ErrGatewayUpstreamFailure
+			}}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-a",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    904,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	select {
+	case <-tokenABlocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upstream failures to accumulate")
+	}
+
+	// The token-a fetcher is now blocked inside its call; the poll goroutine
+	// holds no manager lock. Swap the token; this must reset upstreamFailureCount.
+	_, reused, err := manager.Start(StartInput{
+		Login: "alice",
+		Token: "token-b",
+		Owner: "octo",
+		Repo:  "demo",
+		PR:    904,
+	})
+	if err != nil {
+		t.Fatalf("Start() token refresh error = %v", err)
+	}
+	if !reused {
+		t.Fatal("Start() reused = false, want true: token refresh must reuse existing watch")
+	}
+
+	// Unblock the fetcher so the poll loop can continue with the new client.
+	close(tokenAUnblock)
+
+	snapshot := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool {
+		return s.Terminal
+	})
+	if snapshot.WatchStatus != StatusCompleted {
+		t.Fatalf("WatchStatus = %q, want %q: upstreamFailureCount must be reset on token refresh",
 			snapshot.WatchStatus, StatusCompleted)
 	}
 	if snapshot.FailureReason != nil {
@@ -1292,6 +1388,14 @@ type fakeFetcher struct {
 }
 
 type blockingFetcher struct{}
+
+type callbackFetcher struct {
+	fn func() (*ghclient.ReviewData, error)
+}
+
+func (f *callbackFetcher) GetReviewData(_ context.Context, _, _ string, _ int) (*ghclient.ReviewData, error) {
+	return f.fn()
+}
 
 type persistFailDB struct {
 	*store.DB


### PR DESCRIPTION
## Summary

Implements #37: `ErrGatewayUpstreamFailure` is now tolerated for up to N-1 consecutive poll failures (default N=5) before escalating the watch to `FAILED / AUTH_EXPIRED`.

Previously a single `ErrGatewayUpstreamFailure` immediately terminated the watch with `FailureReasonGitHubError`. Since `upstream_failure` is documented as a transient condition, retrying immediately is almost always correct. After `N` consecutive failures without a successful poll the error is likely to be persistent (e.g., a bad/revoked token), so the watch escalates to `AUTH_EXPIRED` to prompt the user to re-authenticate.

## Changes

### `internal/watch/manager.go`
- **`Options.UpstreamFailureThreshold int`** – configures the escalation budget; defaults to 5 via `defaultUpstreamFailureThreshold`.
- **`Manager.upstreamFailureThreshold int`** – initialized in `NewManager`.
- **`watchState.upstreamFailureCount int`** – per-watch consecutive failure counter.
- **`Manager.handleUpstreamFailure`** – new method called from the poll-error handler when `errors.Is(err, ErrGatewayUpstreamFailure)`:
  - increments `upstreamFailureCount`
  - if count ≥ threshold: escalates with `FailureReasonAuthExpired` and an error message containing the count and original error text
  - if count < threshold: records a transient `lastError`, persists `StatusWatching`, and returns `false` so the poll loop continues
- **success path**: resets `upstreamFailureCount = 0` alongside `lastError = nil`

### `internal/watch/manager_test.go`
- **`TestManagerGatewayUpstreamFailureIsNotAuthExpired`** (updated): uses `UpstreamFailureThreshold: 3`, sends 2 upstream failures followed by a completed review; verifies the watch does **not** escalate to `AUTH_EXPIRED`.
- **`TestManagerGatewayUpstreamFailureEscalatesAfterThreshold`** (new): sends infinite `ErrGatewayUpstreamFailure` with `UpstreamFailureThreshold: 3`; verifies `FAILED / AUTH_EXPIRED` and that `LastError` contains `"consecutive failures"`.
- **`TestManagerGatewayUpstreamFailureCounterResetsOnSuccess`** (new): sends 2 failures → success → 2 failures → completed review with `UpstreamFailureThreshold: 3`; verifies the watch completes successfully, proving the counter was reset by the intermediate success.

## Behaviour at a Glance

| Consecutive `ErrGatewayUpstreamFailure` count | Outcome |
|---|---|
| < threshold (default 5) | Watch continues, `lastError` updated |
| ≥ threshold | `FAILED / AUTH_EXPIRED` — re-authenticate |
| Broken by a successful poll | Counter resets to 0; subsequent failures start a new budget |

## Related

- Depends on #34 (gateway 502-body parsing that introduced `ErrGatewayUpstreamFailure` vs `ErrGatewayRotationFailed` distinction)
- Follows on from #31 (`IsGatewayAuthError` predicate for permanent gateway auth failures)