### PR TITLE
feat(watch): add recovery_hint to watch snapshots for gateway auth failures

### DIFF
--- a/internal/tools/watch.go
+++ b/internal/tools/watch.go
@@ -47,6 +47,7 @@ type ReviewWatchView struct {
 	StaleAt               *string `json:"stale_at,omitempty"`
 	RateLimitResetAt      *string `json:"rate_limit_reset_at,omitempty"`
 	LastError             *string `json:"last_error,omitempty"`
+	RecoveryHint          *string `json:"recovery_hint,omitempty"`
 }
 
 // StartReviewWatchInput is the input schema for start_copilot_review_watch.
@@ -353,6 +354,7 @@ func buildReviewWatchView(snapshot watch.Snapshot, pollInterval time.Duration, n
 		StartedAt:             snapshot.StartedAt.UTC().Format(time.RFC3339),
 		UpdatedAt:             snapshot.UpdatedAt.UTC().Format(time.RFC3339),
 		LastError:             snapshot.LastError,
+		RecoveryHint:          snapshot.RecoveryHint,
 	}
 	if snapshot.ReviewStatus != nil {
 		status := string(*snapshot.ReviewStatus)

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -703,7 +703,7 @@ func (m *Manager) pollOnce(watchID string) bool {
 		var hint *string
 		if ghclient.IsAuthError(err) || ghclient.IsGatewayAuthError(err) {
 			reason = FailureReasonAuthExpired
-			hint = gatewayRecoveryHint(err)
+			hint = authFailureRecoveryHint(err)
 		}
 		m.finishFailureWithHint(w.id, now, reason, err.Error(), hint)
 		return true
@@ -839,10 +839,10 @@ func (m *Manager) finishFailureWithHint(watchID string, now time.Time, reason Fa
 	m.finishState(watchID, now, StatusFailed, &reasonCopy, errText, true, hint)
 }
 
-// gatewayRecoveryHint returns a user-readable recovery instruction for gateway
-// auth sentinel errors. It covers the two permanent failure modes that map to
-// FailureReasonAuthExpired; for all other auth errors a generic hint is returned.
-func gatewayRecoveryHint(err error) *string {
+// authFailureRecoveryHint returns a user-readable recovery instruction for auth
+// failures that map to FailureReasonAuthExpired. Gateway-specific sentinels get
+// targeted messages; all other auth errors receive a generic re-auth hint.
+func authFailureRecoveryHint(err error) *string {
 	switch {
 	case errors.Is(err, ghclient.ErrGatewaySubjectGone):
 		return stringPtr("Re-authenticate: the gateway has no cached token for this user. A fresh client request will re-seed the gateway cache.")
@@ -867,7 +867,7 @@ func (m *Manager) handleUpstreamFailure(watchID string, now time.Time, errText s
 	w.upstreamFailureCount++
 	if w.upstreamFailureCount >= m.upstreamFailureThreshold {
 		count := w.upstreamFailureCount
-		msg := fmt.Sprintf("gateway upstream_failure persisted after %d consecutive failures; re-authenticate: %s", count, errText)
+		msg := fmt.Sprintf("gateway upstream_failure persisted after %d consecutive failures; re-authenticate or retry later: %s", count, errText)
 		reason := FailureReasonAuthExpired
 		hint := stringPtr(fmt.Sprintf("Re-authenticate or retry later: gateway upstream was unreachable for %d consecutive polls.", count))
 		m.markPollLocked(w, now)

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -68,6 +68,7 @@ type Snapshot struct {
 	LastPolledAt     *time.Time
 	RateLimitResetAt *time.Time
 	LastError        *string
+	RecoveryHint     *string
 }
 
 // StartInput identifies a PR watch owned by one authenticated GitHub user.
@@ -180,6 +181,7 @@ type watchState struct {
 	lastError            *string
 	rateLimitResetAt     *time.Time
 	upstreamFailureCount int
+	recoveryHint         *string
 }
 
 // NewManager creates a process-local, memory-only watch manager.
@@ -316,6 +318,7 @@ func (m *Manager) Start(in StartInput) (Snapshot, bool, error) {
 				// New credentials start a fresh upstream-failure budget.
 				existing.upstreamFailureCount = 0
 				existing.lastError = nil
+				existing.recoveryHint = nil
 			}
 			if triggerLinked {
 				existing.triggerLogID = cloneInt64Ptr(triggerLogID)
@@ -522,7 +525,7 @@ func (m *Manager) CancelByID(login, watchID string) (CancelResult, error) {
 		if hasCancelByIDTriggerLogID {
 			cancelByIDTriggerLogID = *state.triggerLogID
 		}
-		m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
+		m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually", nil)
 		snapshot := snapshotFromState(state)
 		m.mu.Unlock()
 		if hasCancelByIDTriggerLogID {
@@ -579,7 +582,7 @@ func (m *Manager) CancelLatest(login, owner, repo string, pr int) (CancelResult,
 			if hasCancelLatestTriggerLogID {
 				cancelLatestTriggerLogID = *state.triggerLogID
 			}
-			m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually")
+			m.finishLocked(state, StatusCancelled, nil, now, "watch was cancelled manually", nil)
 			snapshot := snapshotFromState(state)
 			m.mu.Unlock()
 			if hasCancelLatestTriggerLogID {
@@ -697,10 +700,12 @@ func (m *Manager) pollOnce(watchID string) bool {
 			return m.handleUpstreamFailure(w.id, now, err.Error())
 		}
 		reason := FailureReasonGitHubError
+		var hint *string
 		if ghclient.IsAuthError(err) || ghclient.IsGatewayAuthError(err) {
 			reason = FailureReasonAuthExpired
+			hint = gatewayRecoveryHint(err)
 		}
-		m.finishFailureWithPoll(w.id, now, reason, err.Error())
+		m.finishFailureWithHint(w.id, now, reason, err.Error(), hint)
 		return true
 	}
 
@@ -737,7 +742,7 @@ func (m *Manager) pollOnce(watchID string) bool {
 		} else {
 			current.rateLimitResetAt = cloneTimePtr(&data.RateLimitReset)
 		}
-		m.finishLocked(current, StatusRateLimited, nil, now, formatRateLimitMessage(data.RateLimitRemaining, data.RateLimitReset))
+		m.finishLocked(current, StatusRateLimited, nil, now, formatRateLimitMessage(data.RateLimitRemaining, data.RateLimitReset), nil)
 		m.mu.Unlock()
 		return true
 	}
@@ -764,7 +769,7 @@ func (m *Manager) pollOnce(watchID string) bool {
 			id := entry.ID
 			current.triggerLogID = &id
 		}
-		m.finishLocked(current, terminalStatus, nil, now, "")
+		m.finishLocked(current, terminalStatus, nil, now, "", nil)
 		m.mu.Unlock()
 		return true
 	}
@@ -813,20 +818,39 @@ func (m *Manager) pollOnce(watchID string) bool {
 
 func (m *Manager) finishFailureWithPoll(watchID string, now time.Time, reason FailureReason, errText string) {
 	reasonCopy := reason
-	m.finishState(watchID, now, StatusFailed, &reasonCopy, errText, true)
+	m.finishState(watchID, now, StatusFailed, &reasonCopy, errText, true, nil)
 }
 
 func (m *Manager) finishFailureWithoutPoll(watchID string, now time.Time, reason FailureReason, errText string) {
 	reasonCopy := reason
-	m.finishState(watchID, now, StatusFailed, &reasonCopy, errText, false)
+	m.finishState(watchID, now, StatusFailed, &reasonCopy, errText, false, nil)
 }
 
 func (m *Manager) finishStatusWithPoll(watchID string, now time.Time, status Status, reason *FailureReason, errText string) {
-	m.finishState(watchID, now, status, reason, errText, true)
+	m.finishState(watchID, now, status, reason, errText, true, nil)
 }
 
 func (m *Manager) finishStatusWithoutPoll(watchID string, now time.Time, status Status, reason *FailureReason, errText string) {
-	m.finishState(watchID, now, status, reason, errText, false)
+	m.finishState(watchID, now, status, reason, errText, false, nil)
+}
+
+func (m *Manager) finishFailureWithHint(watchID string, now time.Time, reason FailureReason, errText string, hint *string) {
+	reasonCopy := reason
+	m.finishState(watchID, now, StatusFailed, &reasonCopy, errText, true, hint)
+}
+
+// gatewayRecoveryHint returns a user-readable recovery instruction for gateway
+// auth sentinel errors. It covers the two permanent failure modes that map to
+// FailureReasonAuthExpired; for all other auth errors a generic hint is returned.
+func gatewayRecoveryHint(err error) *string {
+	switch {
+	case errors.Is(err, ghclient.ErrGatewaySubjectGone):
+		return stringPtr("Re-authenticate: the gateway has no cached token for this user. A fresh client request will re-seed the gateway cache.")
+	case errors.Is(err, ghclient.ErrGatewayRotationFailed):
+		return stringPtr("Re-authenticate: your GitHub refresh token was rejected during rotation and cannot be renewed automatically.")
+	default:
+		return stringPtr("Re-authenticate with GitHub to continue watching.")
+	}
 }
 
 // handleUpstreamFailure counts consecutive ErrGatewayUpstreamFailure errors and
@@ -845,8 +869,9 @@ func (m *Manager) handleUpstreamFailure(watchID string, now time.Time, errText s
 		count := w.upstreamFailureCount
 		msg := fmt.Sprintf("gateway upstream_failure persisted after %d consecutive failures; re-authenticate: %s", count, errText)
 		reason := FailureReasonAuthExpired
+		hint := stringPtr(fmt.Sprintf("Re-authenticate or retry later: gateway upstream was unreachable for %d consecutive polls.", count))
 		m.markPollLocked(w, now)
-		m.finishLocked(w, StatusFailed, &reason, now, msg)
+		m.finishLocked(w, StatusFailed, &reason, now, msg, hint)
 		m.mu.Unlock()
 		return true
 	}
@@ -869,7 +894,7 @@ func (m *Manager) handleUpstreamFailure(watchID string, now time.Time, errText s
 	return false
 }
 
-func (m *Manager) finishState(watchID string, now time.Time, status Status, reason *FailureReason, errText string, countedPoll bool) {
+func (m *Manager) finishState(watchID string, now time.Time, status Status, reason *FailureReason, errText string, countedPoll bool, hint *string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -883,7 +908,7 @@ func (m *Manager) finishState(watchID string, now time.Time, status Status, reas
 	} else {
 		w.updatedAt = now
 	}
-	m.finishLocked(w, status, reason, now, errText)
+	m.finishLocked(w, status, reason, now, errText, hint)
 }
 
 func (m *Manager) markStale(watchID, errText string) {
@@ -896,7 +921,7 @@ func (m *Manager) markStale(watchID, errText string) {
 	}
 
 	now := m.now().UTC()
-	m.finishLocked(w, StatusStale, nil, now, errText)
+	m.finishLocked(w, StatusStale, nil, now, errText, nil)
 }
 
 func (m *Manager) markPollLocked(w *watchState, now time.Time) {
@@ -905,9 +930,10 @@ func (m *Manager) markPollLocked(w *watchState, now time.Time) {
 	w.lastPolledAt = timePtr(now)
 }
 
-func (m *Manager) finishLocked(w *watchState, status Status, reason *FailureReason, now time.Time, errText string) {
+func (m *Manager) finishLocked(w *watchState, status Status, reason *FailureReason, now time.Time, errText string, hint *string) {
 	w.status = status
 	w.failureReason = reason
+	w.recoveryHint = hint
 	w.terminal = true
 	w.workerRunning = false
 	w.updatedAt = now
@@ -957,6 +983,7 @@ func snapshotFromState(w *watchState) Snapshot {
 		LastPolledAt:     cloneTimePtr(w.lastPolledAt),
 		RateLimitResetAt: cloneTimePtr(w.rateLimitResetAt),
 		LastError:        cloneStringPtr(w.lastError),
+		RecoveryHint:     cloneStringPtr(w.recoveryHint),
 	}
 }
 

--- a/internal/watch/manager_test.go
+++ b/internal/watch/manager_test.go
@@ -349,6 +349,109 @@ func TestManagerGatewayAuthExpiredFailsWatch(t *testing.T) {
 	}
 }
 
+func TestManagerRecoveryHintGatewayAuthSentinels(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantFrag string // substring expected in RecoveryHint
+	}{
+		{
+			name:     "ErrGatewaySubjectGone",
+			err:      ghclient.ErrGatewaySubjectGone,
+			wantFrag: "re-seed the gateway cache",
+		},
+		{
+			name:     "ErrGatewayRotationFailed",
+			err:      ghclient.ErrGatewayRotationFailed,
+			wantFrag: "refresh token was rejected",
+		},
+	}
+
+	for i, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t)
+			manager := NewManager(db, Options{
+				PollInterval: 5 * time.Millisecond,
+				Threshold:    30 * time.Second,
+				ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
+					return &fakeFetcher{results: []fetchResult{{err: tc.err}}}
+				},
+			})
+			t.Cleanup(manager.Close)
+
+			started, _, err := manager.Start(StartInput{
+				Login: "alice", Token: "tok", Owner: "octo", Repo: "demo",
+				PR: 1100 + i,
+			})
+			if err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+
+			snap := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool { return s.Terminal })
+			if snap.RecoveryHint == nil {
+				t.Fatalf("RecoveryHint = nil, want non-nil for %s", tc.name)
+			}
+			if !strings.Contains(*snap.RecoveryHint, tc.wantFrag) {
+				t.Fatalf("RecoveryHint = %q, want substring %q", *snap.RecoveryHint, tc.wantFrag)
+			}
+		})
+	}
+}
+
+func TestManagerRecoveryHintUpstreamThreshold(t *testing.T) {
+	const threshold = 3
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval:             5 * time.Millisecond,
+		Threshold:                30 * time.Second,
+		UpstreamFailureThreshold: threshold,
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
+			return &fakeFetcher{results: []fetchResult{{err: ghclient.ErrGatewayUpstreamFailure}}}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice", Token: "tok", Owner: "octo", Repo: "demo", PR: 1102,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snap := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool { return s.Terminal })
+	if snap.RecoveryHint == nil {
+		t.Fatalf("RecoveryHint = nil after upstream threshold escalation")
+	}
+	if !strings.Contains(*snap.RecoveryHint, "consecutive") {
+		t.Fatalf("RecoveryHint = %q, want substring \"consecutive\"", *snap.RecoveryHint)
+	}
+}
+
+func TestManagerRecoveryHintNilForNonGatewayError(t *testing.T) {
+	db := openTestDB(t)
+	manager := NewManager(db, Options{
+		PollInterval: 5 * time.Millisecond,
+		Threshold:    30 * time.Second,
+		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
+			return &fakeFetcher{results: []fetchResult{{err: errors.New("generic network error")}}}
+		},
+	})
+	t.Cleanup(manager.Close)
+
+	started, _, err := manager.Start(StartInput{
+		Login: "alice", Token: "tok", Owner: "octo", Repo: "demo", PR: 1103,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	snap := waitForWatch(t, manager, started.WatchID, func(s Snapshot) bool { return s.Terminal })
+	if snap.RecoveryHint != nil {
+		t.Fatalf("RecoveryHint = %q, want nil for non-gateway error", *snap.RecoveryHint)
+	}
+}
+
 func TestManagerGatewayUpstreamFailureIsNotAuthExpired(t *testing.T) {
 	// N-1 consecutive upstream failures followed by a success must NOT escalate
 	// to AUTH_EXPIRED. The watch should complete normally after the success.


### PR DESCRIPTION
## Summary

Closes #39 (PR-B from Issue #29 sub-issue decomposition).

When a watch terminates with `FailureReasonAuthExpired`, the snapshot now includes a `recovery_hint` string that tells the MCP client (or AI agent) what action to take.

## Changes

### `internal/watch/manager.go`
- Added `RecoveryHint *string` to `Snapshot` struct
- Added `recoveryHint *string` to `watchState` struct
- Added `hint *string` parameter to `finishLocked` and `finishState`
- Added `finishFailureWithHint` helper for auth-expiry paths
- Added `gatewayRecoveryHint(err error) *string` helper returning per-sentinel messages
- Error handler dispatches hint for gateway auth failures; upstream threshold escalation includes N-polls message
- All non-auth failure paths pass `nil` (no hint)

### `internal/tools/watch.go`
- Added `RecoveryHint *string` with `json:"recovery_hint,omitempty"` to `ReviewWatchView`
- Populated from snapshot in `buildReviewWatchView`

### `internal/watch/manager_test.go`
- `TestManagerRecoveryHintGatewayAuthSentinels`: asserts hint text for `ErrGatewaySubjectGone` and `ErrGatewayRotationFailed`
- `TestManagerRecoveryHintUpstreamThreshold`: asserts hint includes "consecutive" after threshold escalation
- `TestManagerRecoveryHintNilForNonGatewayError`: asserts `RecoveryHint == nil` for plain errors

## Recovery hint messages

| Failure path | RecoveryHint |
|---|---|
| `ErrGatewaySubjectGone` | Re-authenticate: the gateway has no cached token for this user. A fresh client request will re-seed the gateway cache. |
| `ErrGatewayRotationFailed` | Re-authenticate: your GitHub refresh token was rejected during rotation and cannot be renewed automatically. |
| Other `IsGatewayAuthError` | Re-authenticate with GitHub to continue watching. |
| `ErrGatewayUpstreamFailure` × N (threshold) | Re-authenticate or retry later: gateway upstream was unreachable for N consecutive polls. |
| Non-auth failures | `nil` (field omitted from JSON) |

## Known limitation: recovery_hint is not persisted

`recovery_hint` is memory-only. It is set on `watchState` and copied into `Snapshot` via `snapshotFromState`, but it is **not** stored in the `review_watch` DB row. `snapshotFromReviewWatchEntry` (used for history reads and post-restart queries) always returns `RecoveryHint: nil`. This is intentional scope for this PR — hints are transient guidance for the live watch, not a durable audit record.

## Out of scope (follow-up issues)
- #40: gateway integration test
- #41: Phase C structured error contract alignment
