### PR TITLE
fix(github): Phase C alignment — add ErrGatewayInvalidExpiry to ClassifyGitHubError (#41)

### DIFF
--- a/internal/github/classify.go
+++ b/internal/github/classify.go
@@ -52,6 +52,10 @@ func ClassifyGitHubError(err error) *autherr.AuthError {
 	case errors.Is(err, ErrGatewayBadRequest):
 		// Request arguments rejected by the gateway; caller should not retry.
 		return autherr.NewValidationError()
+	case errors.Is(err, ErrGatewayInvalidExpiry):
+		// Gateway whoami response was missing or contained an unparseable expires_at.
+		// This is a transient gateway response format error; retry may succeed.
+		return autherr.NewTransientUpstreamError()
 	}
 
 	// Primary rate limit (go-github wraps 403 + X-RateLimit-Remaining: 0).

--- a/internal/github/classify_test.go
+++ b/internal/github/classify_test.go
@@ -159,6 +159,8 @@ func TestClassifyGitHubError_GatewaySentinels(t *testing.T) {
 		{"ErrGatewayUnauthorized", ghclient.ErrGatewayUnauthorized, autherr.AUTH_REQUIRED},
 		{"ErrGatewayLoopbackRequired", ghclient.ErrGatewayLoopbackRequired, autherr.AUTH_REQUIRED},
 		{"ErrGatewayBadRequest", ghclient.ErrGatewayBadRequest, autherr.VALIDATION_ERROR},
+		{"ErrGatewayInvalidExpiry", ghclient.ErrGatewayInvalidExpiry, autherr.TRANSIENT_UPSTREAM_ERROR},
+		{"wrapped ErrGatewayInvalidExpiry", fmt.Errorf("outer: %w", ghclient.ErrGatewayInvalidExpiry), autherr.TRANSIENT_UPSTREAM_ERROR},
 		{"wrapped ErrGatewayRotationFailed", fmt.Errorf("outer: %w", ghclient.ErrGatewayRotationFailed), autherr.TOKEN_REFRESH_FAILED},
 		{"wrapped ErrGatewayUpstreamFailure", fmt.Errorf("outer: %w", ghclient.ErrGatewayUpstreamFailure), autherr.TRANSIENT_UPSTREAM_ERROR},
 	}


### PR DESCRIPTION
## Summary

Closes #41 (PR-D: Phase C structured error contract alignment).

This PR completes the Phase C error contract alignment between copilot-review-mcp and the gateway spec in mcp-gateway/docs/auth-error-contract.md.

## Changes

### internal/github/classify.go
Added ErrGatewayInvalidExpiry → TRANSIENT_UPSTREAM_ERROR to ClassifyGitHubError.

ErrGatewayInvalidExpiry is returned by gatewayTokenSource.Token() when the gateway whoami response is missing or has an unparseable xpires_at field. Without this mapping it fell through to FailureReason=GITHUB_ERROR; with it the watch correctly treats the failure as a transient upstream issue that may resolve on retry.

### internal/github/classify_test.go
Added two test cases:
- ErrGatewayInvalidExpiry → TRANSIENT_UPSTREAM_ERROR
- wrapped ErrGatewayInvalidExpiry → TRANSIENT_UPSTREAM_ERROR

## Gap Analysis

Full gap analysis against spec §3.1–§3.3 and §4 was performed. All 3 Known Gaps documented in the spec were already closed by prior PRs (#31, #32, #33/34, #36, #37). The only remaining code gap was ErrGatewayInvalidExpiry not being listed in ClassifyGitHubError.

| Sentinel | Before | After |
|---|---|---|
| ErrGatewayRotationFailed | TOKEN_REFRESH_FAILED ✅ | unchanged |
| ErrGatewaySubjectGone | REAUTH_REQUIRED ✅ | unchanged |
| ErrGatewayUpstreamFailure | TRANSIENT_UPSTREAM_ERROR ✅ | unchanged |
| ErrGatewayUnauthorized | AUTH_REQUIRED ✅ | unchanged |
| ErrGatewayLoopbackRequired | AUTH_REQUIRED ✅ | unchanged |
| ErrGatewayBadRequest | VALIDATION_ERROR ✅ | unchanged |
| ErrGatewayInvalidExpiry | ❌ (fell through to GITHUB_ERROR) | TRANSIENT_UPSTREAM_ERROR ✅ |

Startup-only sentinels (ErrGatewayNonLoopback, ErrGatewayInvalidPath) are intentionally excluded — they are returned only by NewGatewayTokenSource(), never by Token().

## Note on ecovery_hint persistence

ecovery_hint (added in PR #42) is in-memory/view-only. It is populated in watchState but is not persisted to the eview_watch DB table, so snapshotFromReviewWatchEntry (used for historical/restart reads) cannot reconstruct it. This is intentional scope for the current PRs; a future PR could add persistence if needed.

## Related

- Companion doc-update PR in scottlz0310/mcp-gateway: updates uth-error-contract.md to mark all 3 spec gaps as Resolved.