### PR TITLE
docs: add Phase B gateway env vars and archive stale Mcp-Docker issue refs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,3 +15,8 @@ IN_PROGRESS_THRESHOLD_SEC=30
 # 既定 0 = idle で閉じない（#14 対策）。DELETE を送らずに消えたクライアントの session は残るため、
 # メモリ増加を抑えたい場合は正の値（例: 24 時間なら 1440）を指定する。
 MCP_SESSION_TIMEOUT_MIN=0
+
+# Phase B: mcp-gateway internal API (optional — enables gateway-backed token refresh)
+# Both variables must be set together, or neither. The URL must be a loopback address.
+# COPILOT_REVIEW_GATEWAY_INTERNAL_URL=http://127.0.0.1:8080/internal/v1/whoami
+# COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET=<shared-bearer-secret>

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See [docs/usage.md](docs/usage.md) for the full setup guide.
 | `COPILOT_REVIEW_GATEWAY_INTERNAL_URL` | | _(unset)_ | **Phase B** — Full URL of the mcp-gateway internal whoami endpoint (e.g. `http://127.0.0.1:8080/internal/v1/whoami`). Must be a loopback address. Set together with `COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET` or leave both unset. |
 | `COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET` | | _(unset)_ | **Phase B** — Shared bearer secret for the gateway internal API. Must be set together with `COPILOT_REVIEW_GATEWAY_INTERNAL_URL`. |
 
-**Removed in v3.0.0**:`GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `BASE_URL`, `GITHUB_OAUTH_SCOPES`, `SESSION_TTL_MIN`, `TOKEN_CACHE_TTL_MIN`, `TOKEN_EXPIRES_IN_SEC`, `AUTH_MODE`.
+**Removed in v3.0.0**: `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `BASE_URL`, `GITHUB_OAUTH_SCOPES`, `SESSION_TTL_MIN`, `TOKEN_CACHE_TTL_MIN`, `TOKEN_EXPIRES_IN_SEC`, `AUTH_MODE`.
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ See [docs/usage.md](docs/usage.md) for the full setup guide.
 | `SQLITE_PATH` | | `/data/copilot-review.db` | Path to the watch-state database |
 | `IN_PROGRESS_THRESHOLD_SEC` | | `30` | Grace period after a review request before treating the review as in-progress (seconds) |
 | `MCP_SESSION_TIMEOUT_MIN` | | `0` | Idle timeout for Streamable HTTP sessions (minutes). After this period without any HTTP request from a client, the session is closed and subsequent requests with the stale `Mcp-Session-Id` get `404 session not found`. The default `0` disables idle eviction so long-lived clients (Claude Code / IDE / `mcp-gateway`) do not hit the failure mode in #14. Trade-off: orphaned sessions (clients that disappear without sending `DELETE`) remain in memory until process shutdown — set a positive value (e.g. `1440` for 24h) if memory growth is a concern. |
+| `COPILOT_REVIEW_GATEWAY_INTERNAL_URL` | | _(unset)_ | **Phase B** — Full URL of the mcp-gateway internal whoami endpoint (e.g. `http://127.0.0.1:8080/internal/v1/whoami`). Must be a loopback address. Set together with `COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET` or leave both unset. |
+| `COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET` | | _(unset)_ | **Phase B** — Shared bearer secret for the gateway internal API. Must be set together with `COPILOT_REVIEW_GATEWAY_INTERNAL_URL`. |
 
-**Removed in v3.0.0**: `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `BASE_URL`, `GITHUB_OAUTH_SCOPES`, `SESSION_TTL_MIN`, `TOKEN_CACHE_TTL_MIN`, `TOKEN_EXPIRES_IN_SEC`, `AUTH_MODE`.
+**Removed in v3.0.0**:`GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `BASE_URL`, `GITHUB_OAUTH_SCOPES`, `SESSION_TTL_MIN`, `TOKEN_CACHE_TTL_MIN`, `TOKEN_EXPIRES_IN_SEC`, `AUTH_MODE`.
 
 ## Local Development
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -94,6 +94,8 @@ review 反映メモ:
 
 ---
 
+> **Note (archived):** The issues below (#55–#58) were filed in the legacy `scottlz0310/Mcp-Docker` monorepo and have since been implemented in this repository as part of the async watch redesign (memory-only manager → SQLite persistence → tool surface → session/notification layer). The issue links point to the old repo and are kept here for historical reference only.
+
 ## ISSUE 一覧
 
 | ISSUE | 種別 | タイトル | 推奨順 |

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,5 +1,11 @@
 # copilot-review-mcp 改善タスク一覧
 
+> **Archived.** This document was written against the legacy `scottlz0310/Mcp-Docker` monorepo.
+> All issues referenced here (#55–#58 in Mcp-Docker, #63–#68 in Mcp-Docker) have since been
+> implemented in this repository as part of the async watch redesign.
+> The steps and recommendations below are preserved for historical context only and should
+> **not** be treated as pending work.
+
 未整理だったツール動作の調査を経て特定した改善ISSUEと、推奨消化順をまとめる。
 
 ## 長期 redesign
@@ -93,8 +99,6 @@ review 反映メモ:
 - [ ] READMEまたはCLAUDE.mdへの記載箇所:
 
 ---
-
-> **Note (archived):** The issues below (#55–#58) were filed in the legacy `scottlz0310/Mcp-Docker` monorepo and have since been implemented in this repository as part of the async watch redesign (memory-only manager → SQLite persistence → tool surface → session/notification layer). The issue links point to the old repo and are kept here for historical reference only.
 
 ## ISSUE 一覧
 


### PR DESCRIPTION
## Summary

Documentation-only. No code changes.

### Changes

- **\.env.template\**: add commented-out \COPILOT_REVIEW_GATEWAY_INTERNAL_URL\ / \COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET\ entries with explanatory comments (Phase B optional pair)
- **\README.md\**: add both Phase B env vars to the Environment Variables table with description noting loopback requirement and the must-set-together constraint
- **\docs/tasks.md\**: add archived note for Mcp-Docker #55–#58 clarifying those issues were implemented in the current repo and the links are for historical reference only

### Related

Companion tracking issue for the \ecovery_hint\ persistence gap (not in this PR): #46