### PR TITLE
feat: persist recovery_hint in review_watch and reconstruct after restart

### DIFF
--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -39,7 +39,8 @@ CREATE TABLE IF NOT EXISTS review_watch (
     completed_at        INTEGER,
     stale_at            INTEGER,
     last_error          TEXT,
-    rate_limit_reset_at INTEGER
+    rate_limit_reset_at INTEGER,
+    recovery_hint       TEXT
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_review_watch_active_per_pr
     ON review_watch(github_login, owner, repo, pr)
@@ -116,6 +117,43 @@ func Open(path string) (*DB, error) {
 			return nil, fmt.Errorf("migration add prev_review_id: %w", err)
 		}
 	}
+	// Migration: add recovery_hint column to review_watch for persisting auth-failure recovery hints.
+	var recoveryHintExists bool
+	rwRows, err := db.Query(`PRAGMA table_info(review_watch)`)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("migration check review_watch table_info: %w", err)
+	}
+	for rwRows.Next() {
+		var cid int
+		var name, colType string
+		var notNull, pk int
+		var dfltValue interface{}
+		if err := rwRows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
+			_ = rwRows.Close()
+			_ = db.Close()
+			return nil, fmt.Errorf("migration scan review_watch table_info: %w", err)
+		}
+		if name == "recovery_hint" {
+			recoveryHintExists = true
+			break
+		}
+	}
+	if err := rwRows.Err(); err != nil {
+		_ = rwRows.Close()
+		_ = db.Close()
+		return nil, fmt.Errorf("migration iterate review_watch table_info: %w", err)
+	}
+	if err := rwRows.Close(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("migration close review_watch table_info rows: %w", err)
+	}
+	if !recoveryHintExists {
+		if _, err := db.Exec(`ALTER TABLE review_watch ADD COLUMN recovery_hint TEXT`); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("migration add recovery_hint: %w", err)
+		}
+	}
 	if _, err := db.Exec(reviewWatchLookupIndexSQL); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -159,6 +197,7 @@ type ReviewWatchEntry struct {
 	StaleAt          *time.Time
 	LastError        *string
 	RateLimitResetAt *time.Time
+	RecoveryHint     *string
 }
 
 // ReviewWatchFilter scopes a review_watch listing query.
@@ -279,8 +318,9 @@ func (d *DB) UpsertReviewWatch(entry ReviewWatchEntry) error {
 		`INSERT INTO review_watch (
 		    id, github_login, owner, repo, pr, trigger_log_id, resource_uri,
 		    watch_status, review_status, failure_reason, is_active,
-		    started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		    started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at,
+		    recovery_hint
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 		    trigger_log_id      = excluded.trigger_log_id,
 		    resource_uri        = excluded.resource_uri,
@@ -292,7 +332,8 @@ func (d *DB) UpsertReviewWatch(entry ReviewWatchEntry) error {
 		    completed_at        = excluded.completed_at,
 		    stale_at            = excluded.stale_at,
 		    last_error          = excluded.last_error,
-		    rate_limit_reset_at = excluded.rate_limit_reset_at`,
+		    rate_limit_reset_at = excluded.rate_limit_reset_at,
+		    recovery_hint       = excluded.recovery_hint`,
 		entry.ID,
 		entry.GitHubLogin,
 		entry.Owner,
@@ -310,6 +351,7 @@ func (d *DB) UpsertReviewWatch(entry ReviewWatchEntry) error {
 		nullTime(entry.StaleAt),
 		nullString(entry.LastError),
 		nullTime(entry.RateLimitResetAt),
+		nullString(entry.RecoveryHint),
 	)
 	return err
 }
@@ -319,7 +361,8 @@ func (d *DB) GetReviewWatchByID(id string) (*ReviewWatchEntry, error) {
 	row := d.db.QueryRow(
 		`SELECT id, github_login, owner, repo, pr, trigger_log_id, resource_uri,
 		        watch_status, review_status, failure_reason, is_active,
-		        started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at
+		        started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at,
+		        recovery_hint
 		   FROM review_watch
 		  WHERE id = ?`,
 		id,
@@ -332,7 +375,8 @@ func (d *DB) GetLatestReviewWatch(login, owner, repo string, pr int) (*ReviewWat
 	row := d.db.QueryRow(
 		`SELECT id, github_login, owner, repo, pr, trigger_log_id, resource_uri,
 		        watch_status, review_status, failure_reason, is_active,
-		        started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at
+		        started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at,
+		        recovery_hint
 		   FROM review_watch
 		  WHERE github_login = ? AND owner = ? AND repo = ? AND pr = ?
 		  ORDER BY updated_at DESC, started_at DESC, rowid DESC
@@ -346,7 +390,8 @@ func (d *DB) GetLatestReviewWatch(login, owner, repo string, pr int) (*ReviewWat
 func (d *DB) ListReviewWatches(filter ReviewWatchFilter) ([]ReviewWatchEntry, error) {
 	query := `SELECT id, github_login, owner, repo, pr, trigger_log_id, resource_uri,
 	                 watch_status, review_status, failure_reason, is_active,
-	                 started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at
+	                 started_at, updated_at, completed_at, stale_at, last_error, rate_limit_reset_at,
+	                 recovery_hint
 	            FROM review_watch
 	           WHERE github_login = ?`
 	args := []any{filter.GitHubLogin}
@@ -437,6 +482,7 @@ func scanReviewWatch(row scanner) (*ReviewWatchEntry, error) {
 		staleAt          sql.NullInt64
 		lastError        sql.NullString
 		rateLimitResetAt sql.NullInt64
+		recoveryHint     sql.NullString
 		isActive         int
 		startedAtUnix    int64
 		updatedAtUnix    int64
@@ -459,6 +505,7 @@ func scanReviewWatch(row scanner) (*ReviewWatchEntry, error) {
 		&staleAt,
 		&lastError,
 		&rateLimitResetAt,
+		&recoveryHint,
 	); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -476,6 +523,7 @@ func scanReviewWatch(row scanner) (*ReviewWatchEntry, error) {
 	entry.StaleAt = fromNullUnix(staleAt)
 	entry.LastError = fromNullString(lastError)
 	entry.RateLimitResetAt = fromNullUnix(rateLimitResetAt)
+	entry.RecoveryHint = fromNullString(recoveryHint)
 	return &entry, nil
 }
 

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -547,5 +548,119 @@ func TestUpsertReviewWatchNilRecoveryHintRoundTrips(t *testing.T) {
 	}
 	if got.RecoveryHint != nil {
 		t.Fatalf("RecoveryHint = %q, want nil", *got.RecoveryHint)
+	}
+}
+
+// TestRecoveryHintMigrationOnLegacyDB verifies that store.Open applies the
+// ALTER TABLE migration to a pre-existing database that does not yet have the
+// recovery_hint column, and that round-trip reads/writes work after migration.
+func TestRecoveryHintMigrationOnLegacyDB(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-no-hint.db")
+
+	// Build a legacy DB without the recovery_hint column.
+	legacySchema := `
+CREATE TABLE IF NOT EXISTS trigger_log (
+    id           INTEGER PRIMARY KEY,
+    owner        TEXT    NOT NULL,
+    repo         TEXT    NOT NULL,
+    pr           INTEGER NOT NULL,
+    trigger      TEXT    NOT NULL,
+    requested_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+    completed_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS review_watch (
+    id                  TEXT PRIMARY KEY,
+    github_login        TEXT    NOT NULL,
+    owner               TEXT    NOT NULL,
+    repo                TEXT    NOT NULL,
+    pr                  INTEGER NOT NULL,
+    trigger_log_id      INTEGER,
+    resource_uri        TEXT,
+    watch_status        TEXT    NOT NULL,
+    review_status       TEXT,
+    failure_reason      TEXT,
+    is_active           INTEGER NOT NULL DEFAULT 1,
+    started_at          INTEGER NOT NULL,
+    updated_at          INTEGER NOT NULL,
+    completed_at        INTEGER,
+    stale_at            INTEGER,
+    last_error          TEXT,
+    rate_limit_reset_at INTEGER
+    -- no recovery_hint column (legacy schema)
+);
+`
+	rawDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open(legacy) error = %v", err)
+	}
+	if _, err := rawDB.Exec(legacySchema); err != nil {
+		_ = rawDB.Close()
+		t.Fatalf("Exec(legacySchema) error = %v", err)
+	}
+	// Insert a legacy row without recovery_hint.
+	startedAt := time.Now().UTC().Truncate(time.Second)
+	_, err = rawDB.Exec(
+		`INSERT INTO review_watch
+		   (id, github_login, owner, repo, pr, watch_status, is_active, started_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"cw_legacy", "alice", "octo", "demo", 77, "FAILED", 0,
+		startedAt.Unix(), startedAt.Unix(),
+	)
+	if err != nil {
+		_ = rawDB.Close()
+		t.Fatalf("Insert legacy row error = %v", err)
+	}
+	if err := rawDB.Close(); err != nil {
+		t.Fatalf("rawDB.Close() error = %v", err)
+	}
+
+	// Re-open with store.Open — this must apply the migration.
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("store.Open(migrated) error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Legacy row must be readable with RecoveryHint = nil.
+	got, err := db.GetReviewWatchByID("cw_legacy")
+	if err != nil {
+		t.Fatalf("GetReviewWatchByID(legacy) error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetReviewWatchByID(legacy) = nil, want row")
+	}
+	if got.RecoveryHint != nil {
+		t.Fatalf("legacy row RecoveryHint = %q, want nil", *got.RecoveryHint)
+	}
+
+	// New rows with RecoveryHint must round-trip correctly after migration.
+	hint := "Re-authenticate via gh auth login"
+	newEntry := ReviewWatchEntry{
+		ID:           "cw_migrated_hint",
+		GitHubLogin:  "alice",
+		Owner:        "octo",
+		Repo:         "demo",
+		PR:           78,
+		WatchStatus:  "FAILED",
+		IsActive:     false,
+		StartedAt:    startedAt,
+		UpdatedAt:    startedAt,
+		RecoveryHint: strPtr(hint),
+	}
+	if err := db.UpsertReviewWatch(newEntry); err != nil {
+		t.Fatalf("UpsertReviewWatch(post-migration) error = %v", err)
+	}
+	migrated, err := db.GetReviewWatchByID(newEntry.ID)
+	if err != nil {
+		t.Fatalf("GetReviewWatchByID(post-migration) error = %v", err)
+	}
+	if migrated == nil {
+		t.Fatal("GetReviewWatchByID(post-migration) = nil, want row")
+	}
+	if migrated.RecoveryHint == nil {
+		t.Fatal("post-migration RecoveryHint = nil, want non-nil")
+	}
+	if *migrated.RecoveryHint != hint {
+		t.Fatalf("post-migration RecoveryHint = %q, want %q", *migrated.RecoveryHint, hint)
 	}
 }

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -455,3 +455,97 @@ func openTestDB(t *testing.T, path string) *DB {
 }
 
 func strPtr(s string) *string { return &s }
+
+func TestUpsertReviewWatchRoundTripsRecoveryHint(t *testing.T) {
+	db := openTestDB(t, filepath.Join(t.TempDir(), "review-watch-recovery-hint.db"))
+
+	hint := "Re-authenticate: the gateway has no cached token for this user."
+	startedAt := time.Now().UTC().Truncate(time.Second)
+	entry := ReviewWatchEntry{
+		ID:            "cw_hint",
+		GitHubLogin:   "alice",
+		Owner:         "octo",
+		Repo:          "demo",
+		PR:            55,
+		WatchStatus:   "FAILED",
+		FailureReason: strPtr("AUTH_EXPIRED"),
+		IsActive:      false,
+		StartedAt:     startedAt,
+		UpdatedAt:     startedAt,
+		RecoveryHint:  strPtr(hint),
+	}
+	if err := db.UpsertReviewWatch(entry); err != nil {
+		t.Fatalf("UpsertReviewWatch() error = %v", err)
+	}
+
+	// GetReviewWatchByID must reconstruct RecoveryHint.
+	got, err := db.GetReviewWatchByID(entry.ID)
+	if err != nil {
+		t.Fatalf("GetReviewWatchByID() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetReviewWatchByID() = nil, want entry")
+	}
+	if got.RecoveryHint == nil {
+		t.Fatal("RecoveryHint = nil after round-trip, want non-nil")
+	}
+	if *got.RecoveryHint != hint {
+		t.Fatalf("RecoveryHint = %q, want %q", *got.RecoveryHint, hint)
+	}
+
+	// GetLatestReviewWatch must also return RecoveryHint.
+	latest, err := db.GetLatestReviewWatch("alice", "octo", "demo", 55)
+	if err != nil {
+		t.Fatalf("GetLatestReviewWatch() error = %v", err)
+	}
+	if latest == nil {
+		t.Fatal("GetLatestReviewWatch() = nil, want entry")
+	}
+	if latest.RecoveryHint == nil || *latest.RecoveryHint != hint {
+		t.Fatalf("GetLatestReviewWatch().RecoveryHint = %v, want %q", latest.RecoveryHint, hint)
+	}
+
+	// ListReviewWatches must also return RecoveryHint.
+	list, err := db.ListReviewWatches(ReviewWatchFilter{GitHubLogin: "alice", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListReviewWatches() error = %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatal("ListReviewWatches() = empty, want entry")
+	}
+	if list[0].RecoveryHint == nil || *list[0].RecoveryHint != hint {
+		t.Fatalf("ListReviewWatches()[0].RecoveryHint = %v, want %q", list[0].RecoveryHint, hint)
+	}
+}
+
+func TestUpsertReviewWatchNilRecoveryHintRoundTrips(t *testing.T) {
+	db := openTestDB(t, filepath.Join(t.TempDir(), "review-watch-nil-hint.db"))
+
+	startedAt := time.Now().UTC().Truncate(time.Second)
+	entry := ReviewWatchEntry{
+		ID:          "cw_no_hint",
+		GitHubLogin: "alice",
+		Owner:       "octo",
+		Repo:        "demo",
+		PR:          56,
+		WatchStatus: "FAILED",
+		IsActive:    false,
+		StartedAt:   startedAt,
+		UpdatedAt:   startedAt,
+		// RecoveryHint intentionally nil
+	}
+	if err := db.UpsertReviewWatch(entry); err != nil {
+		t.Fatalf("UpsertReviewWatch() error = %v", err)
+	}
+
+	got, err := db.GetReviewWatchByID(entry.ID)
+	if err != nil {
+		t.Fatalf("GetReviewWatchByID() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetReviewWatchByID() = nil, want entry")
+	}
+	if got.RecoveryHint != nil {
+		t.Fatalf("RecoveryHint = %q, want nil", *got.RecoveryHint)
+	}
+}

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -109,14 +109,22 @@ func (sr *sessionRecorder) Write(b []byte) (int, error) {
 	return sr.ResponseWriter.Write(b)
 }
 
-// Flush implements http.Flusher so SSE events are pushed to the client
-// immediately rather than being held in a buffer. It also calls captureSession
-// via once.Do in case the SDK flushes headers before calling Write or WriteHeader.
-func (sr *sessionRecorder) Flush() {
-	sr.once.Do(sr.captureSession)
-	if f, ok := sr.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
-	}
+// sessionRecorderFlusher wraps sessionRecorder and conditionally adds
+// http.Flusher. It is used only when the underlying ResponseWriter itself
+// implements http.Flusher, preserving the optional-interface contract:
+// handlers that check for Flusher support via type-assertion see the same
+// capability as the original writer.
+type sessionRecorderFlusher struct {
+	*sessionRecorder
+	flusher http.Flusher
+}
+
+// Flush calls captureSession (via once.Do) before forwarding to the
+// underlying http.Flusher so SSE events are pushed immediately and the
+// session is registered even when the SDK flushes before Write/WriteHeader.
+func (srf *sessionRecorderFlusher) Flush() {
+	srf.once.Do(srf.captureSession)
+	srf.flusher.Flush()
 }
 
 // ServeHTTP proxies requests to the underlying MCP streamable handler.
@@ -129,7 +137,14 @@ func (h *StreamableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sr := &sessionRecorder{ResponseWriter: w, login: login, handler: h}
-	h.handler.ServeHTTP(sr, r)
+	// Only advertise http.Flusher when the original writer supports it, to
+	// preserve the optional-interface contract for handlers that type-assert
+	// for Flusher (e.g., SSE/MCP streaming).
+	var rw http.ResponseWriter = sr
+	if f, ok := w.(http.Flusher); ok {
+		rw = &sessionRecorderFlusher{sessionRecorder: sr, flusher: f}
+	}
+	h.handler.ServeHTTP(rw, r)
 	// Fallback for implicit header commits: net/http writes headers on handler
 	// return if the handler never called Write, WriteHeader, or Flush. The
 	// once.Do is a no-op when captureSession already ran inside ServeHTTP.

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -80,7 +80,7 @@ type StreamableHandler struct {
 }
 
 // sessionRecorder wraps http.ResponseWriter and calls rememberSession at the
-// moment the SDK first commits response headers (WriteHeader or Write),
+// moment the SDK first commits response headers (WriteHeader, Write, or Flush),
 // ensuring the session is registered before any bytes reach the client. This
 // closes the race where a client reads the Mcp-Session-Id from the response
 // and immediately sends a follow-up request before ServeHTTP returns.
@@ -110,8 +110,14 @@ func (sr *sessionRecorder) Write(b []byte) (int, error) {
 }
 
 // Flush implements http.Flusher so SSE events are pushed to the client
-// immediately rather than being held in a buffer.
+// immediately rather than being held in a buffer. It also calls rememberSession
+// via once.Do in case the SDK flushes headers before calling Write or WriteHeader.
 func (sr *sessionRecorder) Flush() {
+	sr.once.Do(func() {
+		if sid := sr.Header().Get(mcpSessionIDHeader); sid != "" && sr.login != "" {
+			sr.handler.rememberSession(sid, sr.login)
+		}
+	})
 	if f, ok := sr.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -91,33 +91,29 @@ type sessionRecorder struct {
 	once    sync.Once
 }
 
+// captureSession reads Mcp-Session-Id from the response headers and calls
+// rememberSession. It is invoked via once.Do so it runs at most once per request.
+func (sr *sessionRecorder) captureSession() {
+	if sid := sr.Header().Get(mcpSessionIDHeader); sid != "" && sr.login != "" {
+		sr.handler.rememberSession(sid, sr.login)
+	}
+}
+
 func (sr *sessionRecorder) WriteHeader(code int) {
-	sr.once.Do(func() {
-		if sid := sr.Header().Get(mcpSessionIDHeader); sid != "" && sr.login != "" {
-			sr.handler.rememberSession(sid, sr.login)
-		}
-	})
+	sr.once.Do(sr.captureSession)
 	sr.ResponseWriter.WriteHeader(code)
 }
 
 func (sr *sessionRecorder) Write(b []byte) (int, error) {
-	sr.once.Do(func() {
-		if sid := sr.Header().Get(mcpSessionIDHeader); sid != "" && sr.login != "" {
-			sr.handler.rememberSession(sid, sr.login)
-		}
-	})
+	sr.once.Do(sr.captureSession)
 	return sr.ResponseWriter.Write(b)
 }
 
 // Flush implements http.Flusher so SSE events are pushed to the client
-// immediately rather than being held in a buffer. It also calls rememberSession
+// immediately rather than being held in a buffer. It also calls captureSession
 // via once.Do in case the SDK flushes headers before calling Write or WriteHeader.
 func (sr *sessionRecorder) Flush() {
-	sr.once.Do(func() {
-		if sid := sr.Header().Get(mcpSessionIDHeader); sid != "" && sr.login != "" {
-			sr.handler.rememberSession(sid, sr.login)
-		}
-	})
+	sr.once.Do(sr.captureSession)
 	if f, ok := sr.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -128,7 +128,12 @@ func (h *StreamableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.handler.ServeHTTP(&sessionRecorder{ResponseWriter: w, login: login, handler: h}, r)
+	sr := &sessionRecorder{ResponseWriter: w, login: login, handler: h}
+	h.handler.ServeHTTP(sr, r)
+	// Fallback for implicit header commits: net/http writes headers on handler
+	// return if the handler never called Write, WriteHeader, or Flush. The
+	// once.Do is a no-op when captureSession already ran inside ServeHTTP.
+	sr.once.Do(sr.captureSession)
 
 	if r.Method == http.MethodDelete && sessionID != "" {
 		h.forgetSession(sessionID)

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -84,11 +84,21 @@ type StreamableHandler struct {
 // ensuring the session is registered before any bytes reach the client. This
 // closes the race where a client reads the Mcp-Session-Id from the response
 // and immediately sends a follow-up request before ServeHTTP returns.
+//
+// Unwrap allows http.ResponseController and other middleware to traverse the
+// wrapper chain and access optional interfaces (e.g., http.Hijacker, write
+// deadlines) on the original ResponseWriter.
 type sessionRecorder struct {
 	http.ResponseWriter
 	login   string
 	handler *StreamableHandler
 	once    sync.Once
+}
+
+// Unwrap returns the underlying http.ResponseWriter, enabling
+// http.ResponseController to reach optional interfaces on the original writer.
+func (sr *sessionRecorder) Unwrap() http.ResponseWriter {
+	return sr.ResponseWriter
 }
 
 // captureSession reads Mcp-Session-Id from the response headers and calls

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -79,6 +79,44 @@ type StreamableHandler struct {
 	closeOnce     sync.Once
 }
 
+// sessionRecorder wraps http.ResponseWriter and calls rememberSession at the
+// moment the SDK first commits response headers (WriteHeader or Write),
+// ensuring the session is registered before any bytes reach the client. This
+// closes the race where a client reads the Mcp-Session-Id from the response
+// and immediately sends a follow-up request before ServeHTTP returns.
+type sessionRecorder struct {
+	http.ResponseWriter
+	login   string
+	handler *StreamableHandler
+	once    sync.Once
+}
+
+func (sr *sessionRecorder) WriteHeader(code int) {
+	sr.once.Do(func() {
+		if sid := sr.Header().Get(mcpSessionIDHeader); sid != "" && sr.login != "" {
+			sr.handler.rememberSession(sid, sr.login)
+		}
+	})
+	sr.ResponseWriter.WriteHeader(code)
+}
+
+func (sr *sessionRecorder) Write(b []byte) (int, error) {
+	sr.once.Do(func() {
+		if sid := sr.Header().Get(mcpSessionIDHeader); sid != "" && sr.login != "" {
+			sr.handler.rememberSession(sid, sr.login)
+		}
+	})
+	return sr.ResponseWriter.Write(b)
+}
+
+// Flush implements http.Flusher so SSE events are pushed to the client
+// immediately rather than being held in a buffer.
+func (sr *sessionRecorder) Flush() {
+	if f, ok := sr.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // ServeHTTP proxies requests to the underlying MCP streamable handler.
 func (h *StreamableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	login := middleware.LoginFromContext(r.Context())
@@ -88,11 +126,8 @@ func (h *StreamableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.handler.ServeHTTP(w, r)
+	h.handler.ServeHTTP(&sessionRecorder{ResponseWriter: w, login: login, handler: h}, r)
 
-	if responseSessionID := w.Header().Get(mcpSessionIDHeader); responseSessionID != "" && login != "" {
-		h.rememberSession(responseSessionID, login)
-	}
 	if r.Method == http.MethodDelete && sessionID != "" {
 		h.forgetSession(sessionID)
 	}

--- a/internal/tools/server_test.go
+++ b/internal/tools/server_test.go
@@ -343,31 +343,40 @@ func handlerServerSessionCount(handler *StreamableHandler) int {
 	return count
 }
 
-// TestSessionRecorderImplicitCommitFallbackRegistersSession verifies that a
-// session whose Mcp-Session-Id is set by the SDK handler but never sent through
-// an explicit Write, WriteHeader, or Flush call is still registered via the
-// post-ServeHTTP once.Do fallback.
-func TestSessionRecorderImplicitCommitFallbackRegistersSession(t *testing.T) {
-	db := openServerTestDB(t)
-	handler := BuildStreamableHandler(db, 30*time.Second)
-	t.Cleanup(handler.Close)
+// TestStreamableHandlerServeHTTPFallbackRegistersSession verifies the
+// post-ServeHTTP once.Do fallback in StreamableHandler.ServeHTTP.
+// A fake inner handler sets Mcp-Session-Id in the response headers and returns
+// without calling Write, WriteHeader, or Flush — exercising the implicit-commit
+// path where net/http would commit the headers on handler return. The test
+// confirms that sessionLogins is populated despite no explicit commit call.
+func TestStreamableHandlerServeHTTPFallbackRegistersSession(t *testing.T) {
+	fakeInner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Sets the session header but intentionally calls no write methods,
+		// simulating the implicit-commit path.
+		w.Header().Set(mcpSessionIDHeader, "implicit-sid")
+	})
+	h := &StreamableHandler{
+		handler:       fakeInner,
+		sessionLogins: make(map[string]string),
+	}
+	t.Cleanup(h.Close)
 
 	rec := httptest.NewRecorder()
-	rec.Header().Set(mcpSessionIDHeader, "implicit-session-id")
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	ctx := context.WithValue(req.Context(), middleware.ContextKeyLogin, "alice")
+	req = req.WithContext(ctx)
 
-	sr := &sessionRecorder{ResponseWriter: rec, login: "alice", handler: handler}
-	// Simulate handler return without any explicit Write/WriteHeader/Flush.
-	sr.once.Do(sr.captureSession)
+	h.ServeHTTP(rec, req)
 
-	handler.mu.Lock()
-	login, registered := handler.sessionLogins["implicit-session-id"]
-	handler.mu.Unlock()
+	h.mu.Lock()
+	login, registered := h.sessionLogins["implicit-sid"]
+	h.mu.Unlock()
 
 	if !registered {
-		t.Fatal("implicit-commit fallback did not register session via rememberSession")
+		t.Fatal("post-ServeHTTP fallback did not register session for implicit-commit path")
 	}
 	if login != "alice" {
-		t.Fatalf("implicit-commit fallback registered login = %q, want alice", login)
+		t.Fatalf("registered login = %q, want alice", login)
 	}
 }
 

--- a/internal/tools/server_test.go
+++ b/internal/tools/server_test.go
@@ -343,13 +343,41 @@ func handlerServerSessionCount(handler *StreamableHandler) int {
 	return count
 }
 
+// TestSessionRecorderImplicitCommitFallbackRegistersSession verifies that a
+// session whose Mcp-Session-Id is set by the SDK handler but never sent through
+// an explicit Write, WriteHeader, or Flush call is still registered via the
+// post-ServeHTTP once.Do fallback.
+func TestSessionRecorderImplicitCommitFallbackRegistersSession(t *testing.T) {
+	db := openServerTestDB(t)
+	handler := BuildStreamableHandler(db, 30*time.Second)
+	t.Cleanup(handler.Close)
+
+	rec := httptest.NewRecorder()
+	rec.Header().Set(mcpSessionIDHeader, "implicit-session-id")
+
+	sr := &sessionRecorder{ResponseWriter: rec, login: "alice", handler: handler}
+	// Simulate handler return without any explicit Write/WriteHeader/Flush.
+	sr.once.Do(sr.captureSession)
+
+	handler.mu.Lock()
+	login, registered := handler.sessionLogins["implicit-session-id"]
+	handler.mu.Unlock()
+
+	if !registered {
+		t.Fatal("implicit-commit fallback did not register session via rememberSession")
+	}
+	if login != "alice" {
+		t.Fatalf("implicit-commit fallback registered login = %q, want alice", login)
+	}
+}
+
 func handlerSessionLoginCount(handler *StreamableHandler) int {
 	handler.mu.Lock()
 	defer handler.mu.Unlock()
 	return len(handler.sessionLogins)
 }
 
-// TestSessionRecorderFlushRegistersSession verifies that sessionRecorder.Flush
+// TestSessionRecorderFlushRegistersSessionverifies that sessionRecorder.Flush
 // calls rememberSession before forwarding to the underlying http.Flusher,
 // covering the race path where the SDK sets Mcp-Session-Id and flushes headers
 // without a prior Write or WriteHeader call.

--- a/internal/tools/server_test.go
+++ b/internal/tools/server_test.go
@@ -386,7 +386,7 @@ func handlerSessionLoginCount(handler *StreamableHandler) int {
 	return len(handler.sessionLogins)
 }
 
-// TestSessionRecorderFlushRegistersSessionverifies that sessionRecorder.Flush
+// TestSessionRecorderFlushRegistersSession verifies that sessionRecorderFlusher.Flush
 // calls rememberSession before forwarding to the underlying http.Flusher,
 // covering the race path where the SDK sets Mcp-Session-Id and flushes headers
 // without a prior Write or WriteHeader call.
@@ -399,7 +399,8 @@ func TestSessionRecorderFlushRegistersSession(t *testing.T) {
 	rec.Header().Set(mcpSessionIDHeader, "flush-session-id")
 
 	sr := &sessionRecorder{ResponseWriter: rec, login: "alice", handler: handler}
-	sr.Flush()
+	srf := &sessionRecorderFlusher{sessionRecorder: sr, flusher: rec}
+	srf.Flush()
 
 	handler.mu.Lock()
 	login, registered := handler.sessionLogins["flush-session-id"]
@@ -416,7 +417,7 @@ func TestSessionRecorderFlushRegistersSession(t *testing.T) {
 	}
 
 	// A second Flush must not double-register (once.Do guarantee).
-	sr.Flush()
+	srf.Flush()
 	handler.mu.Lock()
 	count := len(handler.sessionLogins)
 	handler.mu.Unlock()

--- a/internal/tools/server_test.go
+++ b/internal/tools/server_test.go
@@ -373,6 +373,23 @@ func TestStreamableHandlerServeHTTPNonFlusherNotExposed(t *testing.T) {
 	}
 }
 
+// TestSessionRecorderUnwrap verifies that sessionRecorder.Unwrap returns the
+// underlying ResponseWriter, enabling http.ResponseController to traverse the
+// middleware chain and reach optional interfaces on the original writer.
+// sessionRecorderFlusher inherits the same path via embedding.
+func TestSessionRecorderUnwrap(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sr := &sessionRecorder{ResponseWriter: rec}
+	if got := sr.Unwrap(); got != rec {
+		t.Errorf("sessionRecorder.Unwrap() = %v, want underlying ResponseWriter", got)
+	}
+
+	srf := &sessionRecorderFlusher{sessionRecorder: sr, flusher: rec}
+	if got := srf.Unwrap(); got != rec {
+		t.Errorf("sessionRecorderFlusher.Unwrap() = %v, want underlying ResponseWriter", got)
+	}
+}
+
 // post-ServeHTTP once.Do fallback in StreamableHandler.ServeHTTP.
 // A fake inner handler sets Mcp-Session-Id in the response headers and returns
 // without calling Write, WriteHeader, or Flush — exercising the implicit-commit

--- a/internal/tools/server_test.go
+++ b/internal/tools/server_test.go
@@ -348,3 +348,42 @@ func handlerSessionLoginCount(handler *StreamableHandler) int {
 	defer handler.mu.Unlock()
 	return len(handler.sessionLogins)
 }
+
+// TestSessionRecorderFlushRegistersSession verifies that sessionRecorder.Flush
+// calls rememberSession before forwarding to the underlying http.Flusher,
+// covering the race path where the SDK sets Mcp-Session-Id and flushes headers
+// without a prior Write or WriteHeader call.
+func TestSessionRecorderFlushRegistersSession(t *testing.T) {
+	db := openServerTestDB(t)
+	handler := BuildStreamableHandler(db, 30*time.Second)
+	t.Cleanup(handler.Close)
+
+	rec := httptest.NewRecorder()
+	rec.Header().Set(mcpSessionIDHeader, "flush-session-id")
+
+	sr := &sessionRecorder{ResponseWriter: rec, login: "alice", handler: handler}
+	sr.Flush()
+
+	handler.mu.Lock()
+	login, registered := handler.sessionLogins["flush-session-id"]
+	handler.mu.Unlock()
+
+	if !registered {
+		t.Fatal("Flush() did not register session via rememberSession")
+	}
+	if login != "alice" {
+		t.Fatalf("Flush() registered login = %q, want alice", login)
+	}
+	if !rec.Flushed {
+		t.Fatal("Flush() did not forward to the underlying http.Flusher")
+	}
+
+	// A second Flush must not double-register (once.Do guarantee).
+	sr.Flush()
+	handler.mu.Lock()
+	count := len(handler.sessionLogins)
+	handler.mu.Unlock()
+	if count != 1 {
+		t.Fatalf("session login count after second Flush = %d, want 1 (once.Do)", count)
+	}
+}

--- a/internal/tools/server_test.go
+++ b/internal/tools/server_test.go
@@ -343,7 +343,36 @@ func handlerServerSessionCount(handler *StreamableHandler) int {
 	return count
 }
 
-// TestStreamableHandlerServeHTTPFallbackRegistersSession verifies the
+
+// nonFlushingResponseWriter wraps http.ResponseWriter without forwarding
+// http.Flusher, so type-asserting for it always fails.
+type nonFlushingResponseWriter struct{ http.ResponseWriter }
+
+// TestStreamableHandlerServeHTTPNonFlusherNotExposed is a regression test for
+// the sessionRecorderFlusher optional-interface contract: when the underlying
+// ResponseWriter does not implement http.Flusher, the writer passed to the
+// inner handler must also not expose http.Flusher.
+func TestStreamableHandlerServeHTTPNonFlusherNotExposed(t *testing.T) {
+	var sawFlusher bool
+	fakeInner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawFlusher = w.(http.Flusher)
+	})
+	h := &StreamableHandler{
+		handler:       fakeInner,
+		sessionLogins: make(map[string]string),
+	}
+	t.Cleanup(h.Close)
+
+	nfw := &nonFlushingResponseWriter{ResponseWriter: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+
+	h.ServeHTTP(nfw, req)
+
+	if sawFlusher {
+		t.Error("inner handler saw http.Flusher on a writer whose underlying ResponseWriter does not support it")
+	}
+}
+
 // post-ServeHTTP once.Do fallback in StreamableHandler.ServeHTTP.
 // A fake inner handler sets Mcp-Session-Id in the response headers and returns
 // without calling Write, WriteHeader, or Flush — exercising the implicit-commit

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -1018,6 +1018,7 @@ func snapshotFromReviewWatchEntry(entry *store.ReviewWatchEntry) Snapshot {
 		LastPolledAt:     nil,
 		RateLimitResetAt: cloneTimePtr(entry.RateLimitResetAt),
 		LastError:        cloneStringPtr(entry.LastError),
+		RecoveryHint:     cloneStringPtr(entry.RecoveryHint),
 	}
 }
 
@@ -1043,6 +1044,7 @@ func (m *Manager) persistLocked(w *watchState) error {
 		StaleAt:          cloneTimePtr(w.staleAt),
 		LastError:        cloneStringPtr(w.lastError),
 		RateLimitResetAt: cloneTimePtr(w.rateLimitResetAt),
+		RecoveryHint:     cloneStringPtr(w.recoveryHint),
 	}
 	return m.db.UpsertReviewWatch(reviewWatch)
 }

--- a/internal/watch/manager_test.go
+++ b/internal/watch/manager_test.go
@@ -455,7 +455,8 @@ func TestManagerRecoveryHintNilForNonGatewayError(t *testing.T) {
 // TestManagerRecoveryHintPersistedAndReconstructed verifies that after a watch
 // terminates with an AUTH_EXPIRED failure reason the recovery_hint written to the
 // DB by persistLocked is correctly reconstructed by snapshotFromReviewWatchEntry
-// when a new manager instance reads the STALE entry (simulating a process restart).
+// when a new manager instance reads the historical terminal entry from the DB
+// (simulating a process restart).
 func TestManagerRecoveryHintPersistedAndReconstructed(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "manager-hint-persist.db")
 
@@ -496,7 +497,8 @@ func TestManagerRecoveryHintPersistedAndReconstructed(t *testing.T) {
 	}
 
 	// Phase 2: open a fresh manager from the same DB — simulates process restart.
-	// The watch is now STALE; GetByID must use snapshotFromReviewWatchEntry.
+	// The watch is a historical terminal entry (FAILED, is_active=false) and will
+	// not be marked STALE by Open; GetByID must use snapshotFromReviewWatchEntry.
 	{
 		db2, err := store.Open(dbPath)
 		if err != nil {

--- a/internal/watch/manager_test.go
+++ b/internal/watch/manager_test.go
@@ -452,6 +452,78 @@ func TestManagerRecoveryHintNilForNonGatewayError(t *testing.T) {
 	}
 }
 
+// TestManagerRecoveryHintPersistedAndReconstructed verifies that after a watch
+// terminates with an AUTH_EXPIRED failure reason the recovery_hint written to the
+// DB by persistLocked is correctly reconstructed by snapshotFromReviewWatchEntry
+// when a new manager instance reads the STALE entry (simulating a process restart).
+func TestManagerRecoveryHintPersistedAndReconstructed(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "manager-hint-persist.db")
+
+	// Phase 1: run manager, trigger an auth-failure, capture WatchID + hint.
+	var watchID string
+	var originalHint string
+	{
+		db, err := store.Open(dbPath)
+		if err != nil {
+			t.Fatalf("store.Open(phase1) error = %v", err)
+		}
+		manager := NewManager(db, Options{
+			PollInterval: 5 * time.Millisecond,
+			Threshold:    30 * time.Second,
+			ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
+				return &fakeFetcher{results: []fetchResult{{err: ghclient.ErrGatewaySubjectGone}}}
+			},
+		})
+
+		started, _, err := manager.Start(StartInput{
+			Login: "alice", Token: "tok", Owner: "octo", Repo: "demo", PR: 2200,
+		})
+		if err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+		watchID = started.WatchID
+
+		snap := waitForWatch(t, manager, watchID, func(s Snapshot) bool { return s.Terminal })
+		if snap.RecoveryHint == nil {
+			t.Fatal("Phase1: RecoveryHint = nil, want non-nil after ErrGatewaySubjectGone")
+		}
+		originalHint = *snap.RecoveryHint
+
+		manager.Close()
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close(phase1) error = %v", err)
+		}
+	}
+
+	// Phase 2: open a fresh manager from the same DB — simulates process restart.
+	// The watch is now STALE; GetByID must use snapshotFromReviewWatchEntry.
+	{
+		db2, err := store.Open(dbPath)
+		if err != nil {
+			t.Fatalf("store.Open(phase2) error = %v", err)
+		}
+		defer func() { _ = db2.Close() }()
+
+		manager2 := NewManager(db2, Options{
+			PollInterval:  time.Hour, // no new polls needed
+			Threshold:     30 * time.Second,
+			ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher { return nil },
+		})
+		defer manager2.Close()
+
+		snap, ok := manager2.GetByID(watchID)
+		if !ok {
+			t.Fatalf("Phase2: GetByID(%q) = not found", watchID)
+		}
+		if snap.RecoveryHint == nil {
+			t.Fatal("Phase2: RecoveryHint = nil after restart, want hint reconstructed from DB")
+		}
+		if *snap.RecoveryHint != originalHint {
+			t.Fatalf("Phase2: RecoveryHint = %q, want %q", *snap.RecoveryHint, originalHint)
+		}
+	}
+}
+
 func TestManagerGatewayUpstreamFailureIsNotAuthExpired(t *testing.T) {
 	// N-1 consecutive upstream failures followed by a success must NOT escalate
 	// to AUTH_EXPIRED. The watch should complete normally after the success.


### PR DESCRIPTION
## Summary

Fixes #46: persist ecovery_hint across process restarts so that auth-failure watches can surface actionable re-authentication hints even after a server restart.

### Changes

#### internal/store/db.go
- Add ecovery_hint TEXT column to the eview_watch DDL.
- Add PRAGMA table_info-based migration that runs ALTER TABLE review_watch ADD COLUMN recovery_hint TEXT on existing databases that pre-date this column (mirrors the existing prev_review_id migration pattern).
- Add RecoveryHint *string field to ReviewWatchEntry; wire it through UpsertReviewWatch, GetReviewWatchByID, GetLatestReviewWatch, ListReviewWatches, and scanReviewWatch.

#### internal/watch/manager.go
- persistLocked(): write RecoveryHint so it is persisted when a watch terminates with an auth failure.
- snapshotFromReviewWatchEntry(): read RecoveryHint from the DB entry when reconstructing a historical watch snapshot (this was the broken path identified in #46).

#### internal/tools/server.go
- Fix a race condition in session-login registration: when the MCP SDK writes the Mcp-Session-Id response header, the client can receive it and immediately send a follow-up request before the post-ServeHTTP ememberSession call runs. This caused TestStreamableHandlerRejectsSessionUserMismatch to be flaky (returning 202 instead of 403).
- Added sessionRecorder, a http.ResponseWriter wrapper that calls ememberSession inside WriteHeader, Write, **and** Flush (via sync.Once) — i.e., at the exact moment headers are committed to the client, before any bytes are transmitted.
- The Flush path guards the same race: if the SDK ever flushes headers before calling Write/WriteHeader, the recorder still registers the session before bytes leave the server.

#### Tests
- internal/store/db_test.go: TestUpsertReviewWatchRoundTripsRecoveryHint, TestUpsertReviewWatchNilRecoveryHintRoundTrips, **TestRecoveryHintMigrationOnLegacyDB** (creates a pre-migration DB without the column, reopens via store.Open, verifies ALTER TABLE ran and both nil and non-nil hints round-trip correctly).
- internal/watch/manager_test.go: TestManagerRecoveryHintPersistedAndReconstructed (end-to-end restart simulation).
