### PR TITLE
fix(cycle): fix all_replied skips resolved threads; add CI/reply debug fields

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -629,33 +630,44 @@ func (c *Client) ReplyToThread(ctx context.Context, threadID, body string) (Repl
 	}, nil
 }
 
-// GetCIStatus returns true when all GitHub Check Runs for the PR's head commit have
-// passed (conclusion: success, skipped, or neutral). Returns true when no check runs exist.
-// Returns false when any run is not yet completed or has a failing conclusion.
-func (c *Client) GetCIStatus(ctx context.Context, owner, repo string, prNumber int) (bool, error) {
+// CIStatus holds the result of a CI check run status query.
+type CIStatus struct {
+	// OK is true when all check runs are completed with a passing conclusion
+	// (success, skipped, or neutral). Also true when no check runs exist.
+	OK bool
+	// PendingChecks contains the names of check runs not yet in "completed" status.
+	PendingChecks []string
+	// FailedChecks contains the names of check runs that completed with a
+	// non-passing conclusion (e.g., failure, cancelled, timed_out, action_required).
+	FailedChecks []string
+}
+
+// GetCIStatus returns a CIStatus for the PR's head commit. Check runs are
+// deduplicated by name, keeping the latest (highest ID) run per name to avoid
+// stale in-progress runs from workflow re-triggers blocking ci_ok.
+func (c *Client) GetCIStatus(ctx context.Context, owner, repo string, prNumber int) (CIStatus, error) {
 	pr, _, err := c.gh.PullRequests.Get(ctx, owner, repo, prNumber)
 	if err != nil {
-		return false, fmt.Errorf("failed to get PR: %w", err)
+		return CIStatus{}, fmt.Errorf("failed to get PR: %w", err)
 	}
 	sha := pr.GetHead().GetSHA()
 	if sha == "" {
-		return false, fmt.Errorf("PR #%d head SHA is empty", prNumber)
+		return CIStatus{}, fmt.Errorf("PR #%d head SHA is empty", prNumber)
 	}
 
+	// Collect all check runs, deduplicating by name (keep latest by ID).
+	latest := make(map[string]*github.CheckRun)
 	opts := &github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}}
 	for {
 		result, resp, err := c.gh.Checks.ListCheckRunsForRef(ctx, owner, repo, sha, opts)
 		if err != nil {
-			return false, fmt.Errorf("failed to list check runs: %w", err)
+			return CIStatus{}, fmt.Errorf("failed to list check runs: %w", err)
 		}
-		for _, r := range result.CheckRuns {
-			if r.GetStatus() != "completed" {
-				return false, nil
-			}
-			switch r.GetConclusion() {
-			case "success", "skipped", "neutral":
-			default:
-				return false, nil
+		for i := range result.CheckRuns {
+			r := result.CheckRuns[i]
+			name := r.GetName()
+			if existing, ok := latest[name]; !ok || r.GetID() > existing.GetID() {
+				latest[name] = r
 			}
 		}
 		if resp == nil || resp.NextPage == 0 {
@@ -663,7 +675,23 @@ func (c *Client) GetCIStatus(ctx context.Context, owner, repo string, prNumber i
 		}
 		opts.Page = resp.NextPage
 	}
-	return true, nil
+
+	var pending, failed []string
+	for name, r := range latest {
+		if r.GetStatus() != "completed" {
+			pending = append(pending, name)
+			continue
+		}
+		switch r.GetConclusion() {
+		case "success", "skipped", "neutral":
+			// passing
+		default:
+			failed = append(failed, name)
+		}
+	}
+	sort.Strings(pending)
+	sort.Strings(failed)
+	return CIStatus{OK: len(pending) == 0 && len(failed) == 0, PendingChecks: pending, FailedChecks: failed}, nil
 }
 
 // ResolveThread resolves a review thread. Returns true if it was already resolved before the call.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -655,7 +655,8 @@ func (c *Client) GetCIStatus(ctx context.Context, owner, repo string, prNumber i
 		return CIStatus{}, fmt.Errorf("PR #%d head SHA is empty", prNumber)
 	}
 
-	// Collect all check runs, deduplicating by name (keep latest by ID).
+	// Collect all check runs, deduplicating by (appID, name) to collapse reruns of the
+	// same check while preserving distinct checks that share a name across different apps.
 	latest := make(map[string]*github.CheckRun)
 	opts := &github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}}
 	for {
@@ -665,9 +666,9 @@ func (c *Client) GetCIStatus(ctx context.Context, owner, repo string, prNumber i
 		}
 		for i := range result.CheckRuns {
 			r := result.CheckRuns[i]
-			name := r.GetName()
-			if existing, ok := latest[name]; !ok || r.GetID() > existing.GetID() {
-				latest[name] = r
+			key := strconv.FormatInt(r.GetApp().GetID(), 10) + ":" + r.GetName()
+			if existing, ok := latest[key]; !ok || r.GetID() > existing.GetID() {
+				latest[key] = r
 			}
 		}
 		if resp == nil || resp.NextPage == 0 {
@@ -677,7 +678,8 @@ func (c *Client) GetCIStatus(ctx context.Context, owner, repo string, prNumber i
 	}
 
 	var pending, failed []string
-	for name, r := range latest {
+	for _, r := range latest {
+		name := r.GetName()
 		if r.GetStatus() != "completed" {
 			pending = append(pending, name)
 			continue

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -643,8 +643,9 @@ type CIStatus struct {
 }
 
 // GetCIStatus returns a CIStatus for the PR's head commit. Check runs are
-// deduplicated by name, keeping the latest (highest ID) run per name to avoid
-// stale in-progress runs from workflow re-triggers blocking ci_ok.
+// deduplicated by (appID, name), keeping the latest (highest ID) run per
+// (app, name) pair. This collapses reruns of the same check while preserving
+// distinct checks that happen to share a name across different GitHub Apps.
 func (c *Client) GetCIStatus(ctx context.Context, owner, repo string, prNumber int) (CIStatus, error) {
 	pr, _, err := c.gh.PullRequests.Get(ctx, owner, repo, prNumber)
 	if err != nil {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -465,8 +465,15 @@ func TestGetCIStatus(t *testing.T) {
 	makeChecksJSON := func(runs ...string) string {
 		return fmt.Sprintf(`{"total_count":%d,"check_runs":[%s]}`, len(runs), join(runs, ","))
 	}
-	makeRun := func(id int64, name, status, conclusion string) string {
-		return fmt.Sprintf(`{"id":%d,"name":%q,"status":%q,"conclusion":%q}`, id, name, status, conclusion)
+	// makeRun builds a check-run JSON fragment. appID is included in the dedup key
+	// (appID:name), so two runs with the same name but different appIDs are treated
+	// as distinct checks. Pass appID=0 to use the default sentinel app (ID 100).
+	makeRun := func(id, appID int64, name, status, conclusion string) string {
+		if appID == 0 {
+			appID = 100
+		}
+		return fmt.Sprintf(`{"id":%d,"name":%q,"status":%q,"conclusion":%q,"app":{"id":%d}}`,
+			id, name, status, conclusion, appID)
 	}
 
 	tests := []struct {
@@ -481,50 +488,60 @@ func TestGetCIStatus(t *testing.T) {
 		},
 		{
 			name:       "all success → true",
-			checksJSON: makeChecksJSON(makeRun(1, "ci/build", "completed", "success")),
+			checksJSON: makeChecksJSON(makeRun(1, 0, "ci/build", "completed", "success")),
 			want:       CIStatus{OK: true},
 		},
 		{
 			name:       "skipped → true",
-			checksJSON: makeChecksJSON(makeRun(1, "ci/lint", "completed", "skipped")),
+			checksJSON: makeChecksJSON(makeRun(1, 0, "ci/lint", "completed", "skipped")),
 			want:       CIStatus{OK: true},
 		},
 		{
 			name:       "neutral → true",
-			checksJSON: makeChecksJSON(makeRun(1, "ci/optional", "completed", "neutral")),
+			checksJSON: makeChecksJSON(makeRun(1, 0, "ci/optional", "completed", "neutral")),
 			want:       CIStatus{OK: true},
 		},
 		{
 			name:       "in_progress (not completed) → false with pending_checks",
-			checksJSON: makeChecksJSON(makeRun(1, "ci/test", "in_progress", "")),
+			checksJSON: makeChecksJSON(makeRun(1, 0, "ci/test", "in_progress", "")),
 			want:       CIStatus{OK: false, PendingChecks: []string{"ci/test"}},
 		},
 		{
 			name:       "failure → false with failed_checks",
-			checksJSON: makeChecksJSON(makeRun(1, "ci/build", "completed", "failure")),
+			checksJSON: makeChecksJSON(makeRun(1, 0, "ci/build", "completed", "failure")),
 			want:       CIStatus{OK: false, FailedChecks: []string{"ci/build"}},
 		},
 		{
 			name: "mixed success and failure → false with failed_checks",
 			checksJSON: makeChecksJSON(
-				makeRun(1, "ci/build", "completed", "success"),
-				makeRun(2, "ci/test", "completed", "failure"),
+				makeRun(1, 0, "ci/build", "completed", "success"),
+				makeRun(2, 0, "ci/test", "completed", "failure"),
 			),
 			want: CIStatus{OK: false, FailedChecks: []string{"ci/test"}},
 		},
 		{
-			name: "duplicate name: latest (higher ID) wins; stale in_progress ignored",
+			name: "same app, same name: latest (higher ID) wins; stale in_progress ignored",
 			checksJSON: makeChecksJSON(
-				makeRun(1, "ci/build", "in_progress", ""),  // older: stale
-				makeRun(2, "ci/build", "completed", "success"), // latest: success
+				makeRun(1, 0, "ci/build", "in_progress", ""),   // older: stale
+				makeRun(2, 0, "ci/build", "completed", "success"), // latest: success
 			),
 			want: CIStatus{OK: true},
 		},
 		{
-			name: "duplicate name: latest (higher ID) is failure",
+			name: "same app, same name: latest (higher ID) is failure",
 			checksJSON: makeChecksJSON(
-				makeRun(1, "ci/build", "completed", "success"), // older
-				makeRun(2, "ci/build", "completed", "failure"), // latest
+				makeRun(1, 0, "ci/build", "completed", "success"), // older
+				makeRun(2, 0, "ci/build", "completed", "failure"), // latest
+			),
+			want: CIStatus{OK: false, FailedChecks: []string{"ci/build"}},
+		},
+		{
+			// Same check name but different apps: both must be retained as distinct checks.
+			// A passing run from app 200 must not hide a failing run from app 300.
+			name: "same name, different apps: both retained; failing check reported",
+			checksJSON: makeChecksJSON(
+				makeRun(1, 200, "ci/build", "completed", "success"), // app 200, passing
+				makeRun(2, 300, "ci/build", "completed", "failure"), // app 300, failing
 			),
 			want: CIStatus{OK: false, FailedChecks: []string{"ci/build"}},
 		},

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -465,53 +465,87 @@ func TestGetCIStatus(t *testing.T) {
 	makeChecksJSON := func(runs ...string) string {
 		return fmt.Sprintf(`{"total_count":%d,"check_runs":[%s]}`, len(runs), join(runs, ","))
 	}
-	makeRun := func(status, conclusion string) string {
-		return fmt.Sprintf(`{"id":1,"status":%q,"conclusion":%q}`, status, conclusion)
+	makeRun := func(id int64, name, status, conclusion string) string {
+		return fmt.Sprintf(`{"id":%d,"name":%q,"status":%q,"conclusion":%q}`, id, name, status, conclusion)
 	}
 
 	tests := []struct {
 		name       string
 		checksJSON string
-		want       bool
+		want       CIStatus
 	}{
 		{
 			name:       "zero check runs → true (CI not configured)",
 			checksJSON: makeChecksJSON(),
-			want:       true,
+			want:       CIStatus{OK: true},
 		},
 		{
 			name:       "all success → true",
-			checksJSON: makeChecksJSON(makeRun("completed", "success")),
-			want:       true,
+			checksJSON: makeChecksJSON(makeRun(1, "ci/build", "completed", "success")),
+			want:       CIStatus{OK: true},
 		},
 		{
 			name:       "skipped → true",
-			checksJSON: makeChecksJSON(makeRun("completed", "skipped")),
-			want:       true,
+			checksJSON: makeChecksJSON(makeRun(1, "ci/lint", "completed", "skipped")),
+			want:       CIStatus{OK: true},
 		},
 		{
 			name:       "neutral → true",
-			checksJSON: makeChecksJSON(makeRun("completed", "neutral")),
-			want:       true,
+			checksJSON: makeChecksJSON(makeRun(1, "ci/optional", "completed", "neutral")),
+			want:       CIStatus{OK: true},
 		},
 		{
-			name:       "in_progress (not completed) → false",
-			checksJSON: makeChecksJSON(makeRun("in_progress", "")),
-			want:       false,
+			name:       "in_progress (not completed) → false with pending_checks",
+			checksJSON: makeChecksJSON(makeRun(1, "ci/test", "in_progress", "")),
+			want:       CIStatus{OK: false, PendingChecks: []string{"ci/test"}},
 		},
 		{
-			name:       "failure → false",
-			checksJSON: makeChecksJSON(makeRun("completed", "failure")),
-			want:       false,
+			name:       "failure → false with failed_checks",
+			checksJSON: makeChecksJSON(makeRun(1, "ci/build", "completed", "failure")),
+			want:       CIStatus{OK: false, FailedChecks: []string{"ci/build"}},
 		},
 		{
-			name: "mixed success and failure → false",
+			name: "mixed success and failure → false with failed_checks",
 			checksJSON: makeChecksJSON(
-				makeRun("completed", "success"),
-				makeRun("completed", "failure"),
+				makeRun(1, "ci/build", "completed", "success"),
+				makeRun(2, "ci/test", "completed", "failure"),
 			),
-			want: false,
+			want: CIStatus{OK: false, FailedChecks: []string{"ci/test"}},
 		},
+		{
+			name: "duplicate name: latest (higher ID) wins; stale in_progress ignored",
+			checksJSON: makeChecksJSON(
+				makeRun(1, "ci/build", "in_progress", ""),  // older: stale
+				makeRun(2, "ci/build", "completed", "success"), // latest: success
+			),
+			want: CIStatus{OK: true},
+		},
+		{
+			name: "duplicate name: latest (higher ID) is failure",
+			checksJSON: makeChecksJSON(
+				makeRun(1, "ci/build", "completed", "success"), // older
+				makeRun(2, "ci/build", "completed", "failure"), // latest
+			),
+			want: CIStatus{OK: false, FailedChecks: []string{"ci/build"}},
+		},
+	}
+
+	ciStatusEqual := func(a, b CIStatus) bool {
+		if a.OK != b.OK {
+			return false
+		}
+		sliceEq := func(x, y []string) bool {
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+		return sliceEq(a.PendingChecks, b.PendingChecks) && sliceEq(a.FailedChecks, b.FailedChecks)
 	}
 
 	for _, tt := range tests {
@@ -533,8 +567,8 @@ func TestGetCIStatus(t *testing.T) {
 			if err != nil {
 				t.Fatalf("GetCIStatus() error = %v", err)
 			}
-			if got != tt.want {
-				t.Errorf("GetCIStatus() = %v, want %v", got, tt.want)
+			if !ciStatusEqual(got, tt.want) {
+				t.Errorf("GetCIStatus() = %+v, want %+v", got, tt.want)
 			}
 		})
 	}
@@ -569,8 +603,8 @@ func TestGetCIStatus(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetCIStatus() error = %v", err)
 		}
-		if got {
-			t.Fatalf("GetCIStatus() = %v, want false", got)
+		if got.OK {
+			t.Fatalf("GetCIStatus() = %+v, want OK=false", got)
 		}
 		if join(pagesSeen, ",") != "1,2" {
 			t.Fatalf("GetCIStatus() did not request all pages, got pages %q, want %q", join(pagesSeen, ","), "1,2")
@@ -607,8 +641,8 @@ func TestGetCIStatus(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetCIStatus() error = %v", err)
 		}
-		if !got {
-			t.Fatalf("GetCIStatus() = %v, want true", got)
+		if !got.OK {
+			t.Fatalf("GetCIStatus() = %+v, want OK=true", got)
 		}
 		if join(pagesSeen, ",") != "1,2" {
 			t.Fatalf("GetCIStatus() did not request all pages, got pages %q, want %q", join(pagesSeen, ","), "1,2")

--- a/internal/tools/cycle.go
+++ b/internal/tools/cycle.go
@@ -177,6 +177,22 @@ func cycleStatusHandler(
 
 		// ── Early exit: max cycles exceeded ────────────────────────────────
 		if in.CyclesDone >= maxCycles {
+			// Fetch threads so all_replied / unresolved_count are accurate on this exit path.
+			rawThreads, err := gh.GetReviewThreads(ctx, in.Owner, in.Repo, in.PR)
+			if err != nil {
+				if result, ok := tryAuthResult(err); ok {
+					return result, CycleStatusOutput{}, nil
+				}
+				return nil, CycleStatusOutput{}, fmt.Errorf("failed to fetch review threads: %w", err)
+			}
+			unresolvedCount := 0
+			for _, t := range rawThreads {
+				if !t.IsResolved {
+					unresolvedCount++
+				}
+			}
+			allReplied, unrepliedThreads := computeAllReplied(rawThreads)
+
 			notes := []string{
 				fmt.Sprintf("■ 最大サイクル数 %d 回に達しました。", maxCycles),
 				fmt.Sprintf("■ PR: https://github.com/%s/%s/pull/%d", in.Owner, in.Repo, in.PR),
@@ -190,9 +206,12 @@ func cycleStatusHandler(
 				CyclesDone:        in.CyclesDone,
 				MaxCycles:         maxCycles,
 				MergeConditions: MergeConditions{
-					CIOK:          ciStatus.OK,
-					PendingChecks: ciStatus.PendingChecks,
-					FailedChecks:  ciStatus.FailedChecks,
+					CIOK:             ciStatus.OK,
+					UnresolvedCount:  unresolvedCount,
+					AllReplied:       allReplied,
+					PendingChecks:    ciStatus.PendingChecks,
+					FailedChecks:     ciStatus.FailedChecks,
+					UnrepliedThreads: unrepliedThreads,
 				},
 				Notes: notes,
 			}, nil

--- a/internal/tools/cycle.go
+++ b/internal/tools/cycle.go
@@ -54,9 +54,12 @@ type CycleStatusInput struct {
 
 // MergeConditions holds the per-condition merge readiness check.
 type MergeConditions struct {
-	CIOK            bool `json:"ci_ok"`
-	UnresolvedCount int  `json:"unresolved_count"`
-	AllReplied      bool `json:"all_replied"`
+	CIOK             bool     `json:"ci_ok"`
+	UnresolvedCount  int      `json:"unresolved_count"`
+	AllReplied       bool     `json:"all_replied"`
+	PendingChecks    []string `json:"pending_checks,omitempty"`    // check run names not yet completed
+	FailedChecks     []string `json:"failed_checks,omitempty"`     // check run names with non-passing conclusion
+	UnrepliedThreads []string `json:"unreplied_threads,omitempty"` // IDs of unresolved threads missing a reply
 }
 
 // CycleStatusOutput is the output schema for get_pr_review_cycle_status.
@@ -72,6 +75,32 @@ type CycleStatusOutput struct {
 }
 
 // ─── Tool 8: get_pr_review_cycle_status ──────────────────────────────────────
+
+// computeAllReplied checks whether all unresolved review threads have a reply
+// (i.e., comments from ≥2 distinct authors). Resolved threads are skipped
+// because they are already handled regardless of reply count.
+// Returns (allReplied, unrepliedThreadIDs).
+func computeAllReplied(threads []ghclient.ReviewThread) (bool, []string) {
+	allReplied := true
+	var unreplied []string
+	for _, t := range threads {
+		if t.IsResolved {
+			continue
+		}
+		uniqueAuthors := make(map[string]struct{})
+		for _, c := range t.Comments {
+			key := strings.TrimSpace(c.Author)
+			if key != "" {
+				uniqueAuthors[key] = struct{}{}
+			}
+		}
+		if len(uniqueAuthors) < 2 {
+			allReplied = false
+			unreplied = append(unreplied, t.ID)
+		}
+	}
+	return allReplied, unreplied
+}
 
 var cycleTool = &mcp.Tool{
 	Name: "get_pr_review_cycle_status",
@@ -138,7 +167,7 @@ func cycleStatusHandler(
 		}
 
 		// Auto-detect CI status early so all exit paths return accurate ci_ok.
-		ciAllSuccess, err := gh.GetCIStatus(ctx, in.Owner, in.Repo, in.PR)
+		ciStatus, err := gh.GetCIStatus(ctx, in.Owner, in.Repo, in.PR)
 		if err != nil {
 			if result, ok := tryAuthResult(err); ok {
 				return result, CycleStatusOutput{}, nil
@@ -160,8 +189,12 @@ func cycleStatusHandler(
 				RereviewReason:    rereviewReason,
 				CyclesDone:        in.CyclesDone,
 				MaxCycles:         maxCycles,
-				MergeConditions:   MergeConditions{CIOK: ciAllSuccess},
-				Notes:             notes,
+				MergeConditions: MergeConditions{
+					CIOK:          ciStatus.OK,
+					PendingChecks: ciStatus.PendingChecks,
+					FailedChecks:  ciStatus.FailedChecks,
+				},
+				Notes: notes,
 			}, nil
 		}
 
@@ -175,31 +208,20 @@ func cycleStatusHandler(
 		}
 
 		unresolvedCount := 0
-		allReplied := true // vacuously true when there are no threads
-
 		for _, t := range rawThreads {
 			if !t.IsResolved {
 				unresolvedCount++
 			}
-			// A thread is "replied" only when there are comments from
-			// at least two distinct authors (for example, Copilot and a user).
-			uniqueAuthors := make(map[string]struct{})
-			for _, c := range t.Comments {
-				authorKey := strings.TrimSpace(c.Author)
-				if authorKey == "" {
-					continue
-				}
-				uniqueAuthors[authorKey] = struct{}{}
-			}
-			if len(uniqueAuthors) < 2 {
-				allReplied = false
-			}
 		}
+		allReplied, unrepliedThreads := computeAllReplied(rawThreads)
 
 		mergeConditions := MergeConditions{
-			CIOK:            ciAllSuccess,
-			UnresolvedCount: unresolvedCount,
-			AllReplied:      allReplied,
+			CIOK:             ciStatus.OK,
+			UnresolvedCount:  unresolvedCount,
+			AllReplied:       allReplied,
+			PendingChecks:    ciStatus.PendingChecks,
+			FailedChecks:     ciStatus.FailedChecks,
+			UnrepliedThreads: unrepliedThreads,
 		}
 
 		// ── Fetch current review status ──────────────────────────────────────
@@ -250,9 +272,9 @@ func cycleStatusHandler(
 
 		// ── Termination condition checks (used for action and notes) ─────────
 		// Condition 1: unresolved=0 and CI=OK.
-		terminateCond1 := unresolvedCount == 0 && ciAllSuccess
+		terminateCond1 := unresolvedCount == 0 && ciStatus.OK
 		// Condition 2: no new Copilot comment for ≥ threshold minutes and CI=OK.
-		terminateCond2 := elapsedMinutes >= noCommentThreshold && ciAllSuccess
+		terminateCond2 := elapsedMinutes >= noCommentThreshold && ciStatus.OK
 
 		// ── Determine recommended_action ──────────────────────────────────────
 		var recommendedAction string
@@ -344,7 +366,7 @@ func cycleStatusHandler(
 				if unresolvedCount > 0 {
 					reasons = append(reasons, fmt.Sprintf("unresolved=%d残存", unresolvedCount))
 				}
-				if !ciAllSuccess {
+				if !ciStatus.OK {
 					reasons = append(reasons, "CI未達成")
 				}
 				if len(reasons) == 0 {

--- a/internal/tools/cycle_allreplied_test.go
+++ b/internal/tools/cycle_allreplied_test.go
@@ -1,0 +1,117 @@
+package tools
+
+import (
+	"testing"
+
+	ghclient "github.com/scottlz0310/copilot-review-mcp/internal/github"
+)
+
+func TestComputeAllReplied(t *testing.T) {
+	comment := func(author string) ghclient.ThreadComment {
+		return ghclient.ThreadComment{Author: author, Body: "body"}
+	}
+
+	tests := []struct {
+		name             string
+		threads          []ghclient.ReviewThread
+		wantAllReplied   bool
+		wantUnreplied    []string
+	}{
+		{
+			name:           "no threads → vacuously true",
+			threads:        nil,
+			wantAllReplied: true,
+			wantUnreplied:  nil,
+		},
+		{
+			name: "only resolved threads → true (resolved threads skipped)",
+			threads: []ghclient.ReviewThread{
+				{ID: "T1", IsResolved: true, Comments: []ghclient.ThreadComment{comment("copilot[bot]")}},
+				{ID: "T2", IsResolved: true, Comments: []ghclient.ThreadComment{comment("copilot[bot]")}},
+			},
+			wantAllReplied: true,
+			wantUnreplied:  nil,
+		},
+		{
+			name: "unresolved thread with 2 authors → true",
+			threads: []ghclient.ReviewThread{
+				{ID: "T1", IsResolved: false, Comments: []ghclient.ThreadComment{
+					comment("copilot[bot]"),
+					comment("alice"),
+				}},
+			},
+			wantAllReplied: true,
+			wantUnreplied:  nil,
+		},
+		{
+			name: "unresolved thread with 1 author → false",
+			threads: []ghclient.ReviewThread{
+				{ID: "T1", IsResolved: false, Comments: []ghclient.ThreadComment{
+					comment("copilot[bot]"),
+				}},
+			},
+			wantAllReplied: false,
+			wantUnreplied:  []string{"T1"},
+		},
+		{
+			name: "resolved thread (1 author) does not block all_replied",
+			threads: []ghclient.ReviewThread{
+				{ID: "T1", IsResolved: true, Comments: []ghclient.ThreadComment{comment("copilot[bot]")}},
+				{ID: "T2", IsResolved: false, Comments: []ghclient.ThreadComment{
+					comment("copilot[bot]"),
+					comment("alice"),
+				}},
+			},
+			wantAllReplied: true,
+			wantUnreplied:  nil,
+		},
+		{
+			name: "mixed: resolved (1 author) + unresolved (1 author) → false, only unresolved in unreplied",
+			threads: []ghclient.ReviewThread{
+				{ID: "T1", IsResolved: true, Comments: []ghclient.ThreadComment{comment("copilot[bot]")}},
+				{ID: "T2", IsResolved: false, Comments: []ghclient.ThreadComment{comment("copilot[bot]")}},
+			},
+			wantAllReplied: false,
+			wantUnreplied:  []string{"T2"},
+		},
+		{
+			name: "multiple unresolved unreplied threads → all listed",
+			threads: []ghclient.ReviewThread{
+				{ID: "T1", IsResolved: false, Comments: []ghclient.ThreadComment{comment("bot")}},
+				{ID: "T2", IsResolved: false, Comments: []ghclient.ThreadComment{comment("bot"), comment("user")}},
+				{ID: "T3", IsResolved: false, Comments: []ghclient.ThreadComment{comment("bot")}},
+			},
+			wantAllReplied: false,
+			wantUnreplied:  []string{"T1", "T3"},
+		},
+		{
+			name: "empty author trimmed and not counted",
+			threads: []ghclient.ReviewThread{
+				{ID: "T1", IsResolved: false, Comments: []ghclient.ThreadComment{
+					{Author: "   ", Body: "noise"},
+					{Author: "bot", Body: "comment"},
+				}},
+			},
+			wantAllReplied: false,
+			wantUnreplied:  []string{"T1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAllReplied, gotUnreplied := computeAllReplied(tt.threads)
+			if gotAllReplied != tt.wantAllReplied {
+				t.Errorf("allReplied = %v, want %v", gotAllReplied, tt.wantAllReplied)
+			}
+			if len(gotUnreplied) != len(tt.wantUnreplied) {
+				t.Errorf("unreplied = %v, want %v", gotUnreplied, tt.wantUnreplied)
+				return
+			}
+			for i, id := range tt.wantUnreplied {
+				if gotUnreplied[i] != id {
+					t.Errorf("unreplied[%d] = %q, want %q", i, gotUnreplied[i], id)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two root causes behind get_pr_review_cycle_status returning ci_ok: false / all_replied: false in PR #48 even when GitHub showed CI green and all threads resolved.

Closes #49

## Root Causes Fixed

### 1. all_replied incorrectly blocked by resolved threads

The old loop iterated ALL threads including resolved ones. A resolved thread where Copilot commented but no human replied had 1 author, causing allReplied = false despite unresolved_count = 0.

Fix: computeAllReplied() skips resolved threads entirely.

### 2. GetCIStatus returned no debug info

Fix: Returns CIStatus struct with OK, PendingChecks, FailedChecks. Deduplicates by check name (latest ID wins).

## Changes

- internal/github/client.go: Added CIStatus struct; rewrote GetCIStatus with deduplication and debug fields
- internal/tools/cycle.go: Added PendingChecks, FailedChecks, UnrepliedThreads to MergeConditions; extracted computeAllReplied helper
- internal/github/client_test.go: Updated for CIStatus return type; added deduplication tests; fixed pagination subtests
- internal/tools/cycle_allreplied_test.go (new): 8 unit tests for computeAllReplied
