### PR TITLE
chore: release v3.2.0

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,6 +9,8 @@
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-05-18
+
 ### 追加
 
 - **Phase B 委譲バックグラウンドアクセス — gateway 統合テスト (PR-C)** — [Issue #40](https://github.com/scottlz0310/copilot-review-mcp/issues/40)（[Issue #29](https://github.com/scottlz0310/copilot-review-mcp/issues/29) の一部）:
@@ -95,3 +97,9 @@
 
 - この独立リポジトリでは、Mcp-Docker 時代の `copilot-review-mcp` service 作業から release continuity を引き継ぐ。git 履歴は移行していない。
 - 関連する設計・移行経緯は `docs/` 配下を参照。
+
+[Unreleased]: https://github.com/scottlz0310/copilot-review-mcp/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/scottlz0310/copilot-review-mcp/compare/v3.1.0...v3.2.0
+[3.1.0]: https://github.com/scottlz0310/copilot-review-mcp/compare/v3.0.0...v3.1.0
+[3.0.0]: https://github.com/scottlz0310/copilot-review-mcp/compare/v2.5.0...v3.0.0
+[2.5.0]: https://github.com/scottlz0310/copilot-review-mcp/releases/tag/v2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-05-18
+
 ### Added
 
 - **Phase B delegated background access — gateway integration tests (PR-C)** for [Issue #40](https://github.com/scottlz0310/copilot-review-mcp/issues/40) (part of [Issue #29](https://github.com/scottlz0310/copilot-review-mcp/issues/29)):
@@ -95,3 +97,9 @@ If you were running with `AUTH_MODE=standalone` or `AUTH_MODE=gateway`:
 
 - This standalone repository preserves release continuity from the original `copilot-review-mcp` service work in Mcp-Docker; git history was not migrated.
 - See `docs/` for related design context and migration history.
+
+[Unreleased]: https://github.com/scottlz0310/copilot-review-mcp/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/scottlz0310/copilot-review-mcp/compare/v3.1.0...v3.2.0
+[3.1.0]: https://github.com/scottlz0310/copilot-review-mcp/compare/v3.0.0...v3.1.0
+[3.0.0]: https://github.com/scottlz0310/copilot-review-mcp/compare/v2.5.0...v3.0.0
+[2.5.0]: https://github.com/scottlz0310/copilot-review-mcp/releases/tag/v2.5.0


### PR DESCRIPTION
## 概要

`copilot-review-mcp v3.2.0` のリリース PR です。
v3.1.0 の git タグは存在しますが GitHub Release 未作成のため、v3.1.0 の変更内容も v3.2.0 に統合しています。

## 主な変更点（v3.1.0 + v3.2.0 統合）

### ✨ 新機能

- **Phase B client core** — `gatewayTokenSource`、`NewClientWithTokenSource`
  - 環境変数: `COPILOT_REVIEW_GATEWAY_INTERNAL_URL` / `COPILOT_REVIEW_GATEWAY_INTERNAL_SECRET`
  - `mcp-gateway` 内部 API (`/internal/v1/whoami`) からトークンを取得するクライアント基盤
- `watch.Options.ClientFactory` シグネチャ拡張

### 🔧 改善

- `recovery_hint` フィールドを各レスポンスに追加
- auth error mapping の改善

### 🧪 テスト

- `gateway_integration_test.go` — 6 シナリオの統合テスト追加

### 🐛 修正

- auth error 種別の誤分類を修正

## 依存関係

- `mcp-gateway v0.4.0` の Phase B API に依存しています
- `mcp-gateway v0.4.0` がリリース・デプロイされた後にこの PR をマージしてください

## リリース後の作業

1. このPRをマージ
2. `v3.2.0` タグを付与して GitHub Release を作成
3. `Mcp-Docker v2.10.0` の PR に進む