### PR TITLE
fix(ci): codecov GPG鍵不具合対策 - fail_ci_if_error を false に変更

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -41,7 +41,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
           flags: go
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   build:
     name: Dockerイメージビルド


### PR DESCRIPTION
## 概要

codecov の GPG 鍵ローテーション不具合により、`codecov-action` が一時的に失敗するケースが報告されている。
`fail_ci_if_error: true` のままでは codecov のインフラ側の問題で CI 全体が停止するため、`false` に変更する。

## 変更内容

- `.github/workflows/lint-test.yml`: `fail_ci_if_error: true` → `false`

## 影響

codecov へのアップロードが失敗しても CI がブロックされなくなる。
カバレッジレポートのアップロード失敗は警告扱いとなり、コード品質チェック自体には影響しない。

## 参考

- [codecov/codecov-action #1806](https://github.com/codecov/codecov-action/issues/1806)

Generated with [Claude Code](https://claude.com/claude-code)