### PR TITLE
docs: @thread-owl 再レビュー依頼フローを skill と architecture に反映

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,6 +9,11 @@
 
 ## [Unreleased]
 
+### 変更
+
+- `docs/skills/pr-review-cycle.md` / `.ja.md` — Phase 6 `REQUEST_REREVIEW` アクションを更新: `request_copilot_review` の呼び出しを `add_issue_comment` による `@thread-owl re-review requested` 投稿に変更。reviewed-side cycle はここで完了し、次の reviewer-side cycle は thread-owl webhook → queue → mcp-resource-subscriber に委譲される。([Issue #69](https://github.com/scottlz0310/review-raven/issues/69))
+- `docs/architecture.md` / `.ja.md` — 再レビュー依頼フローのセクションを追加。review-raven（コメント投稿）・thread-owl（webhook → queue）・mcp-resource-subscriber（購読ブリッジ）の責務境界を文書化。
+
 ### 削除
 
 - **旧 `copilot-review://` URI スキームおよび `COPILOT_REVIEW_*` 環境変数を削除** ([Issue #66](https://github.com/scottlz0310/review-raven/issues/66)):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `docs/skills/pr-review-cycle.md` / `.ja.md` — Phase 6 `REQUEST_REREVIEW` action updated: replaced `request_copilot_review` with posting `@thread-owl re-review requested` via `add_issue_comment`. The reviewed-side cycle now terminates at this point; the next reviewer-side cycle is delegated to the thread-owl webhook → queue → mcp-resource-subscriber chain. ([Issue #69](https://github.com/scottlz0310/review-raven/issues/69))
+- `docs/architecture.md` / `.ja.md` — added Re-review request flow section documenting the responsibility boundary between review-raven (posts comment), thread-owl (webhook → queue), and mcp-resource-subscriber (subscription bridge).
+
 ### Removed
 
 - **Legacy `copilot-review://` URI scheme and `COPILOT_REVIEW_*` env vars removed** ([Issue #66](https://github.com/scottlz0310/review-raven/issues/66)):

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -66,6 +66,20 @@ watch resource のスキームは `review-raven://watch/{id}`。改名前に使�
 
 公開 API 互換維持のため、ツール名（`request_copilot_review`、`start_copilot_review_watch` 等）は変更しない。
 
+## 再レビュー依頼フロー
+
+修正完了後、review-raven は `add_issue_comment` で PR に `@thread-owl re-review requested` を投稿する。これが reviewed-side cycle と reviewer-side cycle の境界となる。
+
+| コンポーネント | 責務 |
+|---|---|
+| **review-raven**（reviewed 側） | 修正 → reply → resolve 完了後に `@thread-owl re-review requested` コメントを投稿する。これが reviewed-side cycle の終端。 |
+| **thread-owl**（reviewer 側） | `issue_comment.created` webhook で `@thread-owl` メンションを検出 → `ReviewCandidate.reason = "re-review-requested"` として queue に積む → `queue://review/queue` resource を更新通知する。 |
+| **mcp-resource-subscriber** | queue resource を購読し、更新を agent workflow に橋渡しする。 |
+
+review-raven は review queue を管理しない。`@thread-owl` コメントが引き渡しポイントであり、投稿後に reviewed-side cycle は完了する。次の reviewer-side cycle は thread-owl の queue から始まる。
+
+この方式は Copilot 固有 API ではなく GitHub の通常 PR conversation を利用するため、任意の reviewer（Copilot・人間・bot）に対して機能する。
+
 ## pr-review-subscribe skill との関係
 
 `pr-review-subscribe` skill は review 取得・スレッド処理・修正 workflow を統合する上位 workflow である。review-raven はその中で reviewed-side MCP provider として機能する。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,20 @@ Watch resources use the `review-raven://watch/{id}` scheme. The legacy `copilot-
 
 Tool names (`request_copilot_review`, `start_copilot_review_watch`, etc.) are unchanged for public API compatibility.
 
+## Re-review request flow
+
+After completing fixes, review-raven posts `@thread-owl re-review requested` on the PR via `add_issue_comment`. This is the boundary between the reviewed-side cycle and the reviewer-side cycle.
+
+| Component | Responsibility |
+|---|---|
+| **review-raven** (reviewed side) | Posts `@thread-owl re-review requested` comment after fix → reply → resolve. This ends the reviewed-side cycle. |
+| **thread-owl** (reviewer side) | Detects the `@thread-owl` mention via `issue_comment.created` webhook → enqueues as `ReviewCandidate.reason = "re-review-requested"` → notifies `queue://review/queue` resource. |
+| **mcp-resource-subscriber** | Subscribes to the queue resource and bridges the update to the agent workflow. |
+
+review-raven does not own or manage the review queue. The `@thread-owl` comment is the handoff point. After posting it, the reviewed-side cycle is complete; the next reviewer-side cycle starts from thread-owl's queue.
+
+This approach uses GitHub's standard PR conversation rather than a Copilot-specific API, so it works with any reviewer identity (Copilot, human, bot).
+
 ## Relation to pr-review-subscribe skill
 
 The `pr-review-subscribe` skill is the upper-level workflow integrating review acquisition, thread handling, and fix workflow. review-raven serves as the reviewed-side MCP provider within that skill.

--- a/docs/skills/pr-review-cycle.ja.md
+++ b/docs/skills/pr-review-cycle.ja.md
@@ -243,9 +243,15 @@ Phase 6 で使用する `fix_type` を決定する:
 @thread-owl re-review requested
 
 修正対応が完了しました。再レビューをお願いします。
+
+<!-- review-raven: cycles_done=N -->
 ```
 
+`N` には現在の `cycles_done` の値を記入する（0 始まり。初回の再レビュー依頼では `cycles_done=0`）。
+
 このコメントが thread-owl に reviewer-side cycle の開始を要求する。reviewed-side cycle はここで完了する。Phase 1 には戻らない。
+
+**再開時の cycle count 復元**: thread-owl queue 通知後に skill が Phase 2 から再開する時点では、`cycles_done` はローカル状態に存在しない。PR の issue comment を検索し、最新の `<!-- review-raven: cycles_done=N -->` アノテーションを見つけて `N` を読み取る。そこに 1 を加算した値を現在の `cycles_done` とする。アノテーションが見つからない場合は `cycles_done = 0` として扱う。
 
 **終了分類**:
 

--- a/docs/skills/pr-review-cycle.ja.md
+++ b/docs/skills/pr-review-cycle.ja.md
@@ -44,8 +44,11 @@ MCP ツールのみを使用し、`mcp-resource-subscriber` などのサブス�
 
 ```
 Phase 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
-                ↑                                              ↓ WAIT / REQUEST_REREVIEW
+                ↑                                              ↓ WAIT
                 └──────────────────────────────────────────────┘
+                                        ↓ REQUEST_REREVIEW
+                              @thread-owl コメント投稿 → reviewed-side cycle 完了
+                              （次の reviewer-side cycle は thread-owl に委譲）
                                         ↓ READY_TO_MERGE
                               Phase 6.5 → Phase 6.6 → Phase 7 → Phase 8
                                         ↓ ESCALATE
@@ -226,13 +229,23 @@ Phase 6 で使用する `fix_type` を決定する:
 |-------------------|---------------|
 | `WAIT` | `cycles_done` をインクリメントして Phase 1 へ戻る |
 | `REPLY_RESOLVE` | Phase 2 へ戻る（未解決スレッドが残っている） |
-| `REQUEST_REREVIEW` | 下記オーバーライドルール参照; 通常は `{CRM}:request_copilot_review` → `cycles_done` インクリメント → Phase 1 |
+| `REQUEST_REREVIEW` | 下記オーバーライドルール参照; 通常は `{GH}:add_issue_comment` で `@thread-owl re-review requested` を投稿（下記フォーマット参照）→ 現在の reviewed-side cycle を完了。次の reviewer-side cycle は thread-owl webhook → queue → mcp-resource-subscriber に委譲。Phase 1 には戻らない。 |
 | `READY_TO_MERGE` | Phase 6.5 へ |
 | `ESCALATE` | 分類・報告（下記参照）してサイクル終了 |
 
 **`REQUEST_REREVIEW` オーバーライド**: `recommended_action = REQUEST_REREVIEW` かつ
 `cycles_done ≥ 1` かつ 今サイクルの Phase 2 での未解決スレッド数 = 0 の場合、
 再レビューを依頼しない。`READY_TO_MERGE` として扱い Phase 6.5 へ進む。
+
+**`REQUEST_REREVIEW` コメントフォーマット**: `{GH}:add_issue_comment` で以下を投稿する:
+
+```markdown
+@thread-owl re-review requested
+
+修正対応が完了しました。再レビューをお願いします。
+```
+
+このコメントが thread-owl に reviewer-side cycle の開始を要求する。reviewed-side cycle はここで完了する。Phase 1 には戻らない。
 
 **終了分類**:
 
@@ -340,7 +353,7 @@ Codecov 等のカバレッジ PR コメントを確認する（存在しない�
 | ツール名 | 用途 |
 |---------|------|
 | `{CRM}:get_copilot_review_status` | GitHub 上のレビュー状態を即時確認 |
-| `{CRM}:request_copilot_review` | レビューを依頼 |
+| `{CRM}:request_copilot_review` | 初回レビューを依頼（Phase 0 のみ。再レビュー依頼には使用しない） |
 | `{CRM}:start_copilot_review_watch` | async watch 開始（即時 return） |
 | `{CRM}:get_copilot_review_watch_status` | watch の現在状態をポーリング |
 | `{CRM}:cancel_copilot_review_watch` | watch をキャンセル |

--- a/docs/skills/pr-review-cycle.md
+++ b/docs/skills/pr-review-cycle.md
@@ -231,9 +231,15 @@ Follow `recommended_action`:
 @thread-owl re-review requested
 
 The requested changes have been addressed. Please review again.
+
+<!-- review-raven: cycles_done=N -->
 ```
 
+Replace `N` with the current value of `cycles_done` (0-based; e.g., `cycles_done=0` on the first re-review request).
+
 This comment signals thread-owl to enqueue a reviewer-side cycle. The reviewed-side cycle ends here; do NOT loop back to Phase 1.
+
+**Cycle count recovery on restart**: When the skill re-enters at Phase 2 after a thread-owl queue notification, `cycles_done` is no longer available in local state. Recover it by searching PR issue comments for the most recent `<!-- review-raven: cycles_done=N -->` annotation and parsing `N`. Increment it by 1 to get the current cycle count. If no annotation is found, treat `cycles_done` as 0.
 
 **Termination classification**:
 

--- a/docs/skills/pr-review-cycle.md
+++ b/docs/skills/pr-review-cycle.md
@@ -42,8 +42,11 @@ This skill relies only on MCP tools — no `mcp-resource-subscriber` or other su
 
 ```
 Phase 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
-                ↑                                              ↓ WAIT / REQUEST_REREVIEW
+                ↑                                              ↓ WAIT
                 └──────────────────────────────────────────────┘
+                                        ↓ REQUEST_REREVIEW
+                              Post @thread-owl comment → reviewed-side cycle complete
+                              (next reviewer-side cycle delegated to thread-owl)
                                         ↓ READY_TO_MERGE
                               Phase 6.5 → Phase 6.6 → Phase 7 → Phase 8
                                         ↓ ESCALATE
@@ -216,11 +219,21 @@ Follow `recommended_action`:
 |-------------------|-------------|
 | `WAIT` | Increment `cycles_done`, return to Phase 1 |
 | `REPLY_RESOLVE` | Return to Phase 2 (unresolved threads remain) |
-| `REQUEST_REREVIEW` | See override rule; otherwise call `{CRM}:request_copilot_review` → increment `cycles_done` → Phase 1 |
+| `REQUEST_REREVIEW` | See override rule; otherwise post `@thread-owl re-review requested` via `{GH}:add_issue_comment` (see format below) → current reviewed-side cycle complete. Next reviewer-side cycle is delegated to the thread-owl webhook → queue → mcp-resource-subscriber. |
 | `READY_TO_MERGE` | → Phase 6.5 |
 | `ESCALATE` | Classify and report (see below), then stop |
 
 **`REQUEST_REREVIEW` override**: If `recommended_action = REQUEST_REREVIEW` AND `cycles_done ≥ 1` AND unresolved thread count from Phase 2 of this cycle = 0, do **not** request another review. Treat as `READY_TO_MERGE` and proceed to Phase 6.5.
+
+**`REQUEST_REREVIEW` comment format**: Post the following via `{GH}:add_issue_comment`:
+
+```markdown
+@thread-owl re-review requested
+
+The requested changes have been addressed. Please review again.
+```
+
+This comment signals thread-owl to enqueue a reviewer-side cycle. The reviewed-side cycle ends here; do NOT loop back to Phase 1.
 
 **Termination classification**:
 
@@ -326,7 +339,7 @@ If any other condition is not met, report the missing items and await instructio
 | Tool | Purpose |
 |------|---------|
 | `{CRM}:get_copilot_review_status` | Instant check of review state on GitHub |
-| `{CRM}:request_copilot_review` | Request a review |
+| `{CRM}:request_copilot_review` | Request an initial review (Phase 0 only; not used for re-review) |
 | `{CRM}:start_copilot_review_watch` | Start async watch (returns immediately) |
 | `{CRM}:get_copilot_review_watch_status` | Poll current watch state |
 | `{CRM}:cancel_copilot_review_watch` | Cancel a watch |


### PR DESCRIPTION
## Summary

- `docs/skills/pr-review-cycle.md` / `.ja.md`: Phase 6 `REQUEST_REREVIEW` アクションを更新
  - `{CRM}:request_copilot_review` 呼び出し → `{GH}:add_issue_comment` で `@thread-owl re-review requested` 投稿
  - 投稿後に Phase 1（watch 再開始）には戻らない
  - 「現在の reviewed-side cycle を完了し、次の reviewer-side cycle は thread-owl webhook → queue → mcp-resource-subscriber に委譲する」と明記
  - フロー図を更新（`WAIT / REQUEST_REREVIEW` ループ → `WAIT` ループ + `REQUEST_REREVIEW` → cycle complete）
  - `request_copilot_review` の用途を Phase 0 初回依頼のみと明記
- `docs/architecture.md` / `.ja.md`: 再レビュー依頼フローのセクションを追加
  - review-raven / thread-owl / mcp-resource-subscriber の責務境界を文書化
  - `@thread-owl` comment が reviewed-side / reviewer-side の境界であることを明記

docs-only。Go コードの変更なし。

Closes #69

## Test plan

- [ ] フロー図が意図通り更新されていることを確認
- [ ] Phase 6 `REQUEST_REREVIEW` の説明が正しいことを確認
- [ ] `architecture.md` の新セクションが `re-review-scheme.md` 設計書と整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)