### PR TITLE
docs(skills): split pr-review-cycle into Copilot-only and add thread-owl-review-cycle (#71)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,10 +9,14 @@
 
 ## [Unreleased]
 
+### 追加
+
+- `docs/skills/thread-owl-review-cycle.md` / `.ja.md` — thread-owl reviewed-side cycle 用の新 skill を追加。ページネーション付き GraphQL でレビュースレッドを取得し、分類・修正・返信・resolve を行い、再レビューが必要な場合は `@thread-owl re-review requested` コメントを投稿して cycle を完了する。次の reviewer-side cycle は thread-owl webhook が起動する。([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
+
 ### 変更
 
-- `docs/skills/pr-review-cycle.md` / `.ja.md` — Phase 6 `REQUEST_REREVIEW` アクションを更新: `request_copilot_review` の呼び出しを `add_issue_comment` による `@thread-owl re-review requested` 投稿に変更。reviewed-side cycle はここで完了し、次の reviewer-side cycle は thread-owl webhook → queue → mcp-resource-subscriber に委譲される。([Issue #69](https://github.com/scottlz0310/review-raven/issues/69))
-- `docs/architecture.md` / `.ja.md` — 再レビュー依頼フローのセクションを追加。review-raven（コメント投稿）・thread-owl（webhook → queue）・mcp-resource-subscriber（購読ブリッジ）の責務境界を文書化。
+- `docs/skills/pr-review-cycle.md` / `.ja.md` — **Copilot review 専用** スキルとして明示的にスコープを限定。Phase 6 `REQUEST_REREVIEW` を `request_copilot_review` + Copilot watch ループ（当初設計）に戻した。スコープ注意書きと `## 関連スキル`（`thread-owl-review-cycle` へのリンク）を追加。([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
+- `docs/architecture.md` / `.ja.md` — 再レビュー依頼フローのセクションを追加。review-raven（コメント投稿）・thread-owl（webhook → queue）・mcp-resource-subscriber（購読ブリッジ）の責務境界を文書化。([Issue #69](https://github.com/scottlz0310/review-raven/issues/69))
 
 ### 削除
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `docs/skills/thread-owl-review-cycle.md` / `.ja.md` — new skill for the thread-owl reviewed-side cycle. Reads review threads via paginated GraphQL, classifies and fixes, replies and resolves, then posts `@thread-owl re-review requested` as the re-review path. The reviewed-side cycle ends there; the next reviewer-side cycle is triggered by thread-owl's webhook. ([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
+
 ### Changed
 
-- `docs/skills/pr-review-cycle.md` / `.ja.md` — Phase 6 `REQUEST_REREVIEW` action updated: replaced `request_copilot_review` with posting `@thread-owl re-review requested` via `add_issue_comment`. The reviewed-side cycle now terminates at this point; the next reviewer-side cycle is delegated to the thread-owl webhook → queue → mcp-resource-subscriber chain. ([Issue #69](https://github.com/scottlz0310/review-raven/issues/69))
-- `docs/architecture.md` / `.ja.md` — added Re-review request flow section documenting the responsibility boundary between review-raven (posts comment), thread-owl (webhook → queue), and mcp-resource-subscriber (subscription bridge).
+- `docs/skills/pr-review-cycle.md` / `.ja.md` — explicitly scoped to **Copilot review only**. Phase 6 `REQUEST_REREVIEW` reverted to `request_copilot_review` + Copilot watch loop (as originally designed). Added scope callout and `## See Also` link to `thread-owl-review-cycle`. ([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
+- `docs/architecture.md` / `.ja.md` — added Re-review request flow section documenting the responsibility boundary between review-raven (posts comment), thread-owl (webhook → queue), and mcp-resource-subscriber (subscription bridge). ([Issue #69](https://github.com/scottlz0310/review-raven/issues/69))
 
 ### Removed
 

--- a/docs/skills/pr-review-cycle.ja.md
+++ b/docs/skills/pr-review-cycle.ja.md
@@ -1,14 +1,17 @@
 ---
 name: pr-review-cycle
-description: レビュー完了を async watch ポーリング（mcp-resource-subscriber 不要）で待機してから PR レビュー対応サイクル（スレッド取得→分類・採否判断→修正→返信→サイクル評価→サマリ投稿）を自律実行する。PR 作成直後・レビュー依頼直後に呼び出す。マージは自律実行しない。
+description: "Copilot review 専用スキル。async watch ポーリングで Copilot レビュー完了を待機し、reviewed-side cycle（スレッド取得→分類→修正→返信→Copilot 再レビュー依頼→サマリ投稿）を自律実行する。thread-owl レビュー用は thread-owl-review-cycle を使うこと。"
 ---
 
 # pr-review-cycle スキル
 
 [English](pr-review-cycle.md)
 
-`review-raven` サーバーの watch ツール群を使い、レビュー完了を
-**async watch ポーリング**で待機してから PR レビュー対応サイクルを自律実行するスキル。
+> **スコープ: Copilot review 専用。**
+> このスキルは Copilot review の async watch ポーリングによる取得を対象とする。
+> **thread-owl** によるレビューには [`thread-owl-review-cycle`](thread-owl-review-cycle.ja.md) を使うこと。
+
+`review-raven` サーバーの watch ツール群を使い、**Copilot review** の完了を **async watch ポーリング**で待機してから PR レビュー対応サイクルを自律実行するスキル。修正が必要な場合は `request_copilot_review` で Copilot に直接再レビューを依頼する。`@thread-owl` 再レビューコメントは投稿しない。
 
 MCP ツールのみを使用し、`mcp-resource-subscriber` などのサブスクリプション系外部 CLI は不要。
 `mcp-resource-subscriber` が利用できない環境向けのポーリングベース代替スキル（`pr-review-subscribe` の代替）。
@@ -44,11 +47,8 @@ MCP ツールのみを使用し、`mcp-resource-subscriber` などのサブス�
 
 ```
 Phase 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
-                ↑                                              ↓ WAIT
+                ↑                                              ↓ WAIT / REQUEST_REREVIEW
                 └──────────────────────────────────────────────┘
-                                        ↓ REQUEST_REREVIEW
-                              @thread-owl コメント投稿 → reviewed-side cycle 完了
-                              （次の reviewer-side cycle は thread-owl に委譲）
                                         ↓ READY_TO_MERGE
                               Phase 6.5 → Phase 6.6 → Phase 7 → Phase 8
                                         ↓ ESCALATE
@@ -229,29 +229,13 @@ Phase 6 で使用する `fix_type` を決定する:
 |-------------------|---------------|
 | `WAIT` | `cycles_done` をインクリメントして Phase 1 へ戻る |
 | `REPLY_RESOLVE` | Phase 2 へ戻る（未解決スレッドが残っている） |
-| `REQUEST_REREVIEW` | 下記オーバーライドルール参照; 通常は `{GH}:add_issue_comment` で `@thread-owl re-review requested` を投稿（下記フォーマット参照）→ 現在の reviewed-side cycle を完了。次の reviewer-side cycle は thread-owl webhook → queue → mcp-resource-subscriber に委譲。Phase 1 には戻らない。 |
+| `REQUEST_REREVIEW` | 下記オーバーライドルール参照; 通常は `{CRM}:request_copilot_review` → `cycles_done` インクリメント → Phase 1 へ戻る |
 | `READY_TO_MERGE` | Phase 6.5 へ |
 | `ESCALATE` | 分類・報告（下記参照）してサイクル終了 |
 
 **`REQUEST_REREVIEW` オーバーライド**: `recommended_action = REQUEST_REREVIEW` かつ
 `cycles_done ≥ 1` かつ 今サイクルの Phase 2 での未解決スレッド数 = 0 の場合、
 再レビューを依頼しない。`READY_TO_MERGE` として扱い Phase 6.5 へ進む。
-
-**`REQUEST_REREVIEW` コメントフォーマット**: `{GH}:add_issue_comment` で以下を投稿する:
-
-```markdown
-@thread-owl re-review requested
-
-修正対応が完了しました。再レビューをお願いします。
-
-<!-- review-raven: cycles_done=N -->
-```
-
-`N` には現在の `cycles_done` の値を記入する（0 始まり。初回の再レビュー依頼では `cycles_done=0`）。
-
-このコメントが thread-owl に reviewer-side cycle の開始を要求する。reviewed-side cycle はここで完了する。Phase 1 には戻らない。
-
-**再開時の cycle count 復元**: thread-owl queue 通知後に skill が Phase 2 から再開する時点では、`cycles_done` はローカル状態に存在しない。PR の issue comment を検索し、最新の `<!-- review-raven: cycles_done=N -->` アノテーションを見つけて `N` を読み取る。そこに 1 を加算した値を現在の `cycles_done` とする。アノテーションが見つからない場合は `cycles_done = 0` として扱う。
 
 **終了分類**:
 
@@ -359,7 +343,7 @@ Codecov 等のカバレッジ PR コメントを確認する（存在しない�
 | ツール名 | 用途 |
 |---------|------|
 | `{CRM}:get_copilot_review_status` | GitHub 上のレビュー状態を即時確認 |
-| `{CRM}:request_copilot_review` | 初回レビューを依頼（Phase 0 のみ。再レビュー依頼には使用しない） |
+| `{CRM}:request_copilot_review` | Copilot review を依頼・再依頼（Phase 0 および Phase 6 の `REQUEST_REREVIEW`） |
 | `{CRM}:start_copilot_review_watch` | async watch 開始（即時 return） |
 | `{CRM}:get_copilot_review_watch_status` | watch の現在状態をポーリング |
 | `{CRM}:cancel_copilot_review_watch` | watch をキャンセル |
@@ -368,3 +352,9 @@ Codecov 等のカバレッジ PR コメントを確認する（存在しない�
 | `{CRM}:get_pr_review_cycle_status` | サイクル評価・次アクション判定 |
 | `{GH}:add_issue_comment` | PR にコメント投稿 |
 | `{GH}:create_issue` | フォローアップトラッキング Issue を作成 |
+
+---
+
+## 関連スキル
+
+- [`thread-owl-review-cycle`](thread-owl-review-cycle.ja.md) — thread-owl レビュー用。再レビュー依頼経路は `@thread-owl` コメント投稿（Copilot watch ループではない）。

--- a/docs/skills/pr-review-cycle.md
+++ b/docs/skills/pr-review-cycle.md
@@ -1,13 +1,17 @@
 ---
 name: pr-review-cycle
-description: Waits for review completion via async watch polling (no mcp-resource-subscriber CLI required), then autonomously runs the PR review response cycle (fetch threads → classify & accept/reject → fix → reply → evaluate cycle → post summary). Invoke immediately after creating a PR or requesting a review. Does not merge autonomously.
+description: "Copilot review acquisition via async watch polling. Waits for Copilot review completion, then autonomously runs the reviewed-side cycle (fetch threads → classify → fix → reply → re-request Copilot review if needed → post summary). For thread-owl reviewers, use thread-owl-review-cycle instead."
 ---
 
 # pr-review-cycle Skill
 
 [日本語](pr-review-cycle.ja.md)
 
-A skill that uses the `review-raven` MCP server's watch tools to wait for review completion via **async watch polling**, then autonomously runs the PR review response cycle.
+> **Scope: Copilot review only.**
+> This skill is for Copilot review acquisition via async watch polling.
+> For reviews posted by **thread-owl**, use [`thread-owl-review-cycle`](thread-owl-review-cycle.md) instead.
+
+A skill that uses the `review-raven` MCP server's watch tools to wait for **Copilot review** completion via **async watch polling**, then autonomously runs the PR review response cycle. When fixes are required, the next Copilot review is requested directly via `request_copilot_review` — this skill does NOT post `@thread-owl` re-review comments.
 
 This skill relies only on MCP tools — no `mcp-resource-subscriber` or other subscription-based CLI is required. It is the polling-based alternative to `pr-review-subscribe` for environments where `mcp-resource-subscriber` is unavailable.
 
@@ -42,11 +46,8 @@ This skill relies only on MCP tools — no `mcp-resource-subscriber` or other su
 
 ```
 Phase 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
-                ↑                                              ↓ WAIT
+                ↑                                              ↓ WAIT / REQUEST_REREVIEW
                 └──────────────────────────────────────────────┘
-                                        ↓ REQUEST_REREVIEW
-                              Post @thread-owl comment → reviewed-side cycle complete
-                              (next reviewer-side cycle delegated to thread-owl)
                                         ↓ READY_TO_MERGE
                               Phase 6.5 → Phase 6.6 → Phase 7 → Phase 8
                                         ↓ ESCALATE
@@ -219,27 +220,11 @@ Follow `recommended_action`:
 |-------------------|-------------|
 | `WAIT` | Increment `cycles_done`, return to Phase 1 |
 | `REPLY_RESOLVE` | Return to Phase 2 (unresolved threads remain) |
-| `REQUEST_REREVIEW` | See override rule; otherwise post `@thread-owl re-review requested` via `{GH}:add_issue_comment` (see format below) → current reviewed-side cycle complete. Next reviewer-side cycle is delegated to the thread-owl webhook → queue → mcp-resource-subscriber. |
+| `REQUEST_REREVIEW` | See override rule; otherwise call `{CRM}:request_copilot_review` → increment `cycles_done` → return to Phase 1 |
 | `READY_TO_MERGE` | → Phase 6.5 |
 | `ESCALATE` | Classify and report (see below), then stop |
 
 **`REQUEST_REREVIEW` override**: If `recommended_action = REQUEST_REREVIEW` AND `cycles_done ≥ 1` AND unresolved thread count from Phase 2 of this cycle = 0, do **not** request another review. Treat as `READY_TO_MERGE` and proceed to Phase 6.5.
-
-**`REQUEST_REREVIEW` comment format**: Post the following via `{GH}:add_issue_comment`:
-
-```markdown
-@thread-owl re-review requested
-
-The requested changes have been addressed. Please review again.
-
-<!-- review-raven: cycles_done=N -->
-```
-
-Replace `N` with the current value of `cycles_done` (0-based; e.g., `cycles_done=0` on the first re-review request).
-
-This comment signals thread-owl to enqueue a reviewer-side cycle. The reviewed-side cycle ends here; do NOT loop back to Phase 1.
-
-**Cycle count recovery on restart**: When the skill re-enters at Phase 2 after a thread-owl queue notification, `cycles_done` is no longer available in local state. Recover it by searching PR issue comments for the most recent `<!-- review-raven: cycles_done=N -->` annotation and parsing `N`. Increment it by 1 to get the current cycle count. If no annotation is found, treat `cycles_done` as 0.
 
 **Termination classification**:
 
@@ -345,7 +330,7 @@ If any other condition is not met, report the missing items and await instructio
 | Tool | Purpose |
 |------|---------|
 | `{CRM}:get_copilot_review_status` | Instant check of review state on GitHub |
-| `{CRM}:request_copilot_review` | Request an initial review (Phase 0 only; not used for re-review) |
+| `{CRM}:request_copilot_review` | Request or re-request a Copilot review (Phase 0 and Phase 6 `REQUEST_REREVIEW`) |
 | `{CRM}:start_copilot_review_watch` | Start async watch (returns immediately) |
 | `{CRM}:get_copilot_review_watch_status` | Poll current watch state |
 | `{CRM}:cancel_copilot_review_watch` | Cancel a watch |
@@ -354,3 +339,9 @@ If any other condition is not met, report the missing items and await instructio
 | `{CRM}:get_pr_review_cycle_status` | Evaluate cycle and determine next action |
 | `{GH}:add_issue_comment` | Post a comment to the PR |
 | `{GH}:create_issue` | Create a follow-up tracking issue |
+
+---
+
+## See Also
+
+- [`thread-owl-review-cycle`](thread-owl-review-cycle.md) — For reviews posted by thread-owl. Uses `@thread-owl re-review requested` comment as the re-review path instead of Copilot watch.

--- a/docs/skills/thread-owl-review-cycle.ja.md
+++ b/docs/skills/thread-owl-review-cycle.ja.md
@@ -104,9 +104,9 @@ gh api graphql -f query='
 ```
 
 - `pageInfo.hasNextPage` が `true` の場合、`-f cursor=<endCursor>` で繰り返して全件取得する。
-- `isResolved = false` のスレッドを収集する。
+- `isResolved = false` **かつ** ルートコメントの author が `thread-owl` のスレッドを収集する。他のレビュアー（Copilot・human reviewer 等）が投稿したスレッドはこのスキルのスコープ外としてスキップする。
 - 各スレッドの `id`（PRRT ノード ID — resolve mutation 用）とルートコメントの `databaseId`（返信用）を記録する。
-- 未解決スレッドが 0 件: `termination_status = READY_TO_MERGE` で **Phase 6.5** へ進む。
+- thread-owl による未解決スレッドが 0 件: `termination_status = READY_TO_MERGE` で **Phase 6.5** へ進む。
 - 1 件以上: **Phase 3** へ進む。
 
 ## Phase 3: 分類・採否判断（自律）

--- a/docs/skills/thread-owl-review-cycle.ja.md
+++ b/docs/skills/thread-owl-review-cycle.ja.md
@@ -1,0 +1,334 @@
+---
+name: thread-owl-review-cycle
+description: "thread-owl レビュー用の reviewed-side cycle スキル。thread-owl のレビュースレッドを読み、分類・修正・返信・resolve を行い、再レビューが必要な場合は @thread-owl re-review requested コメントを投稿して cycle を完了する。mcp-resource-subscriber が queue://review/queue 更新を検知した後、または既存の thread-owl レビュースレッドがある状態で呼び出す。"
+---
+
+# thread-owl-review-cycle スキル
+
+[English](thread-owl-review-cycle.md)
+
+> **スコープ: thread-owl レビュー専用。**
+> このスキルは reviewer が **thread-owl** の場合の reviewed-side cycle を担当する。
+> **Copilot** review（async watch ポーリング）には [`pr-review-cycle`](pr-review-cycle.ja.md) を使うこと。
+
+thread-owl がレビュアーの場合に reviewed-side cycle を実行するスキル。Copilot watch ループはない。エントリーは `mcp-resource-subscriber` による `queue://review/queue` resource 更新の検知、または既存の thread-owl レビュースレッドの確認によって行う。
+
+再レビュー依頼は `@thread-owl re-review requested` PR コメントとして投稿する。reviewed-side cycle はそこで完了し、次の reviewer-side cycle は thread-owl の webhook が起動する。
+
+> **このファイルについて**
+> `docs/skills/thread-owl-review-cycle.ja.md` はリポジトリ共有用テンプレートです。
+> 個人の AI エージェント設定（`~/.claude/skills/` 等）にコピーしてご利用ください。
+> MCP サーバーキーはお使いの環境に合わせて読み替えてください。
+
+---
+
+## セットアップ
+
+### 必要な MCP サーバー
+
+| サーバー | 役割 | 参照 |
+|---------|------|------|
+| `github` | PR コメント投稿・Issue 作成 | [README.ja.md](../../README.ja.md) |
+
+> このスキルでは `review-raven` MCP ツールは使用しない。スレッドの読み取りは `gh` CLI（GraphQL）で行う。
+
+### プレースホルダーの読み替え
+
+| プレースホルダー | 役割 | 例 |
+|----------------|------|-----|
+| `{GH}` | `github` サーバーツール | `mcp__github__*` |
+
+---
+
+## 全体フロー
+
+```
+Phase 0（エントリー・cycles_done 復元）
+  |
+  v
+Phase U2: スレッド取得 → Phase 3: 分類 → Phase 4: 修正 → Phase U5: 返信/resolve
+                                                                    |
+                                                        Phase U6: サイクル評価
+                                                                    |
+                                    ┌───────────────────────────────┘
+                                    ↓ READY_TO_MERGE（再レビュー不要）
+                          Phase 6.5 → Phase 6.6 → Phase 7 → Phase 8
+                                    ↓ ESCALATE（最大サイクル超過）
+                          Phase 6.5 → Phase 7 → Phase 8
+                                    ↓ REQUEST_REREVIEW（cycles_done < max_cycles）
+                          @thread-owl コメント投稿 → reviewed-side cycle 完了
+```
+
+---
+
+## Phase 0: エントリー・サイクルカウント復元
+
+1. `owner`、`repo`、`pr` を確定する。
+2. `max_cycles = 3` を設定する（必要に応じて調整）。
+3. `cycles_done` を PR コメント履歴から復元する:
+   - PR の issue comment を検索し、最新の `<!-- review-raven: cycles_done=N -->` を見つける。
+   - 見つかった場合: `cycles_done = N + 1`。
+   - 見つからない場合: `cycles_done = 0`。
+4. Phase U2 へ進む。
+
+## Phase U2: スレッド取得
+
+ページネーション付き GraphQL で全レビュースレッドを取得する:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            comments(first: 10) {
+              nodes {
+                databaseId
+                body
+                path
+                line
+                author { login }
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner=<owner> -f repo=<repo> -F pr=<pr>
+```
+
+- `pageInfo.hasNextPage` が `true` の場合、`-f cursor=<endCursor>` で繰り返して全件取得する。
+- `isResolved = false` のスレッドを収集する。
+- 各スレッドの `id`（PRRT ノード ID — resolve mutation 用）とルートコメントの `databaseId`（返信用）を記録する。
+- 未解決スレッドが 0 件: `termination_status = READY_TO_MERGE` で **Phase 6.5** へ進む。
+- 1 件以上: **Phase 3** へ進む。
+
+## Phase 3: 分類・採否判断（自律）
+
+各未解決コメントを以下の基準で分類し、`accept` / `reject` を自律的に決定する:
+
+| 分類 | 基準 |
+|------|------|
+| `blocking` | 実行時エラー・データ整合性の破壊・セキュリティリスク・破壊的変更・公開記録の不整合 |
+| `non-blocking` | テスト追加・ログ改善・プライバシー・一貫性の改善など対応推奨だが必須ではないもの |
+| `suggestion` | 設計・命名・構造・保守性の改善提案 |
+
+**Reject 制約 — スコープ外・先送りはトラッキング Issue 必須。**
+`out-of-scope`、`deferred`、`follow-up` を理由とする reject は、フォローアップ Issue にトレース可能になるまで完了とみなさない。
+
+フォローアップ Issue が不要な reject 理由:
+- `already-handled` — コミット / PR / Issue を引用する。
+- `invalid-premise` — 誤解の内容を説明する。
+- `wont-fix` — 明示的な不対応決定。「後で対応」と書いてはならない。
+
+修正前に以下のテーブルを提示する:
+
+```
+| # | スレッド ID | 分類 | 採否 | 概要 | reject 理由 | フォローアップ Issue |
+|---|------------|------|------|------|------------|---------------------|
+```
+
+`fix_type` を決定する:
+
+| fix_type | 該当ケース |
+|----------|-----------|
+| `logic` | コードの動作またはテストのみの変更 |
+| `spec_change` | 公開ドキュメント・API・ワークフロー・互換性記録のセマンティクス変更 |
+| `trivial` | typo・フォーマット・文言のみの修正 |
+| `none` | 修正なし（全 reject） |
+
+## Phase 4: 修正＋コミット
+
+1. `git status --short --branch` を実行する。
+2. `accept` した項目のみ修正する。
+3. 修正粒度: 1 スレッド = 1 論理変更単位（atomic）。
+4. 全修正完了後にビルド・テストを再実行する。
+5. Phase 4 完了後に**まとめて 1 コミット**する（Conventional Commits 形式）。
+6. ユーザーが明示的に求めない限り force push しない。
+
+## Phase U5: 返信＋resolve
+
+**返信**: `{GH}:add_reply_to_pull_request_comment` を使う:
+- `owner`、`repo`、`pull_number`: Phase 0 で確定した値
+- `comment_id`: Phase U2 のルートコメント `databaseId`
+- 修正済み: コミットと具体的な修正内容を言及する。
+- reject: 理由を明確に述べる（下記 reject 返信ルール参照）。
+
+**resolve**: GraphQL mutation で実行する:
+
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { id isResolved }
+    }
+  }
+' -f threadId=<PRRT_node_id>
+```
+
+Issue 作成・リンクが不可能な場合を除き常に resolve する。
+
+### Reject 返信ルール
+
+#### 1. 既存 Issue のリンク
+`Tracked by #xxx` または `Follow-up: #xxx` を含める。Issue が実際にその内容をカバーしていることを確認する。
+
+#### 2. 新規フォローアップ Issue の作成
+`{GH}:create_issue` で Issue を作成する。`Follow-up: #<番号>` を返信に含め、Phase 3 テーブルと Phase 7 サマリに番号を記録する。
+
+#### 3. 明示的な `Won't fix`
+`Won't fix` と具体的な理由を書く。「後で対応」「フォローアップ予定」という表現は禁止。
+
+#### 4. Issue 作成・リンクが不可能な場合
+スレッドを resolve しない。Phase 7 に `untracked — needs follow-up issue` として記録する。
+
+## Phase U6: サイクル評価・再レビュー判断
+
+**ステップ 1**: 未解決スレッドを再取得（Phase U2 クエリを再実行）。
+- 未解決 > 0: 想定外。報告して `needs user decision` で停止する。
+
+**ステップ 2**: `need_re_review` を判断（未解決 = 0 の場合のみ）:
+
+| fix_type | blocking accept あり? | need_re_review |
+|----------|----------------------|----------------|
+| `none` | — | **no** |
+| `trivial` | — | **no** |
+| `logic` または `spec_change` | いずれの場合も | **yes** |
+| いずれも | 1 件以上 | **yes** |
+
+**ステップ 3**: ルーティング
+
+- `need_re_review = no` → **Phase 6.5**（`termination_status = READY_TO_MERGE`）
+- `need_re_review = yes` かつ `cycles_done ≥ max_cycles` → 終了分類して **Phase 6.5**
+- `need_re_review = yes` かつ `cycles_done < max_cycles` → `@thread-owl` コメント投稿（下記フォーマット参照）→ **reviewed-side cycle 完了**
+
+### 終了分類
+
+| 分類 | 条件 | マージへの影響 |
+|------|------|----------------|
+| ✅ `READY_TO_MERGE` | 未解決 = 0、再レビュー不要 | 安全 — 通常のマージゲート |
+| 🟡 `ESCALATE — Clean` | 最大サイクル超過 かつ 最終サイクルの accept に `blocking` なし | おそらく安全 — 未検証の旨を注記 |
+| 🔴 `ESCALATE — Unverified Fix` | 最大サイクル超過 かつ 最終サイクルで `blocking` fix を 1 件以上 accept したが再レビューなし | 危険 — マージ前に人間レビュー推奨 |
+
+Phase 7 用に記録する: `termination_status`、`final_cycle_fix_types`、`unverified_blocking_commits`。
+
+### 再レビュー依頼コメントフォーマット
+
+`{GH}:add_issue_comment` で以下を投稿する:
+
+```markdown
+@thread-owl re-review requested
+
+修正対応が完了しました。再レビューをお願いします。
+
+<!-- review-raven: cycles_done=N -->
+```
+
+`N` には現在の `cycles_done` の値を記入する。このアノテーションは次の thread-owl queue 通知後にスキルが Phase 0 から再開する際の `cycles_done` 復元に使用される。
+
+**reviewed-side cycle はここで完了する。Phase U2 には戻らない。**
+次の reviewer-side cycle は thread-owl の `issue_comment.created` webhook → queue → mcp-resource-subscriber 通知によって起動される。
+
+---
+
+## Phase 6.5: CI 確認
+
+1. `gh pr checks <PR番号>` を実行する。
+2. 全ジョブ SUCCESS → Phase 6.6 へ。
+3. 失敗ジョブあり: `gh run view <run-id> --log-failed` でログを確認する。
+   - 修正可能 → Phase 4 へ戻る。
+   - 修正困難 → ユーザーに報告して停止。
+
+`gh` が利用不可な場合は `{GH}` / GitHub MCP server で確認する。どちらでも確認できない場合は `CI: unknown` を報告して停止する。
+
+## Phase 6.6: カバレッジ確認
+
+Codecov 等のカバレッジ PR コメントを確認する（存在しない場合はスキップ → Phase 7 へ）。
+
+- テストで解消できるカバレッジのギャップがある場合: Phase 4 へ戻る（`fix_type = logic`）。
+- 問題がない場合: Phase 7 へ進む。
+
+## Phase 7: サマリコメント投稿
+
+`{GH}:add_issue_comment` で以下を PR に投稿する:
+
+```markdown
+## レビュー対応サマリ（thread-owl）
+
+### 修正内容
+- （概要を箇条書き）
+
+### 採否判断
+- accept: N 件
+- reject: M 件
+  - Thread <threadId> (PRRT_xxx): （理由）
+
+### 先送り・スコープ外項目
+- なし | <リスト: Thread <threadId> — Follow-up: #N>
+
+### 検証
+- CI: ...
+- 未解決スレッド: 0
+- サイクルステータス: <termination_status>
+  - `ESCALATE — Unverified Fix` の場合: 理由・未検証コミット SHA・「マージ前に人間レビュー推奨」を明記
+- 最終サイクル修正タイプ: blocking × N, non-blocking × N, suggestion × N, trivial × N
+- cycles_done: N
+- 再レビュー: @thread-owl コメント投稿済み | 不要 | ESCALATE（最大サイクル超過）
+```
+
+**`先送り・スコープ外項目` ルール**: `out-of-scope` / `deferred` / `follow-up` を理由とする全 reject をフォローアップ Issue 番号付きでリストしなければならない。「なし」は該当 reject が 0 件かつ Phase U5 ステップ 4 で未解決スレッドがない場合のみ許容。
+
+## Phase 8: マージ判断
+
+**自律的にマージしない。** ユーザーからの明示的な指示を待つ。
+
+マージ条件（ユーザー指示時に満たすこと）:
+- CI 全ジョブ SUCCESS
+- 未解決レビュースレッド = 0 件
+- 全スレッドに返信済み
+- 未解決の `blocking` 項目なし
+- `termination_status` が `READY_TO_MERGE` または `ESCALATE — Clean`
+
+`termination_status = ESCALATE — Unverified Fix` の場合:
+1. CI グリーン・未解決 0 件でも **マージ準備完了とは報告しない**。
+2. 未検証コミット SHA を付けて警告を明確に提示する。
+3. ユーザーがそれでもマージを要求する場合は、未検証 blocking 修正を手動レビュー済みであることを明示的に確認してから進める。
+
+`termination_status = WAITING_FOR_REVIEW(thread-owl)`（再レビューコメント投稿済み）の場合:
+1. マージ準備完了とは報告しない。
+2. 「thread-owl への再レビュー依頼済み。次の review cycle 待機中。」と報告する。
+
+---
+
+## 注意事項
+
+- `max_cycles` デフォルトは 3。Phase 0 で必要に応じて調整する。
+- `cycles_done` はサーバー状態ではなく `<!-- review-raven: cycles_done=N -->` PR コメントアノテーションから復元する。
+- 再レビュー依頼は `@thread-owl` PR コメント経由。`request_copilot_review` は使用しない。
+- このスキルは Copilot watch を開始せず、`get_pr_review_cycle_status` を呼ばない。
+- 修正粒度: スレッド単位 atomic（1 スレッド = 1 論理変更単位）。
+- コミット戦略: Phase 4 完了後まとめて 1 コミット（Conventional Commits 形式）。
+- Phase 8 は明示指示待ち（操作安全基準）。
+
+---
+
+## ツール対応表
+
+| ツール | 用途 |
+|-------|------|
+| `gh` CLI | GraphQL スレッド取得・resolve mutation・CI 確認 |
+| `{GH}:add_reply_to_pull_request_comment` | レビュースレッドに返信 |
+| `{GH}:add_issue_comment` | PR サマリ・再レビュー依頼コメント投稿 |
+| `{GH}:create_issue` | フォローアップトラッキング Issue を作成 |
+
+---
+
+## 関連スキル
+
+- [`pr-review-cycle`](pr-review-cycle.ja.md) — Copilot review 専用。再レビューは `request_copilot_review` + async watch ループ（`@thread-owl` コメントは使用しない）。

--- a/docs/skills/thread-owl-review-cycle.md
+++ b/docs/skills/thread-owl-review-cycle.md
@@ -104,9 +104,9 @@ gh api graphql -f query='
 ```
 
 - If `pageInfo.hasNextPage` is `true`, repeat with `-f cursor=<endCursor>` until exhausted.
-- Collect threads where `isResolved = false`.
+- Collect threads where `isResolved = false` **and** the root comment author is `thread-owl`. Skip threads posted by other reviewers (Copilot, human reviewers, etc.) — they are out of scope for this skill.
 - Record each thread's `id` (PRRT node ID — for resolve mutation) and root comment `databaseId` (for replies).
-- If 0 unresolved threads: proceed to **Phase 6.5** with `termination_status = READY_TO_MERGE`.
+- If 0 unresolved thread-owl threads: proceed to **Phase 6.5** with `termination_status = READY_TO_MERGE`.
 - Otherwise: proceed to **Phase 3**.
 
 ## Phase 3: Classify & Accept/Reject (Autonomous)

--- a/docs/skills/thread-owl-review-cycle.md
+++ b/docs/skills/thread-owl-review-cycle.md
@@ -1,0 +1,335 @@
+---
+name: thread-owl-review-cycle
+description: "Reviewed-side cycle for thread-owl reviewers. Reads thread-owl review threads, classifies & fixes, replies, resolves, then posts @thread-owl re-review requested when re-review is needed. Invoke after mcp-resource-subscriber detects a queue://review/queue update, or when existing thread-owl review threads are present."
+---
+
+# thread-owl-review-cycle Skill
+
+[日本語](thread-owl-review-cycle.ja.md)
+
+> **Scope: thread-owl reviews only.**
+> This skill handles the reviewed-side cycle when the reviewer is **thread-owl**.
+> For **Copilot** reviews (async watch polling), use [`pr-review-cycle`](pr-review-cycle.md) instead.
+
+A skill for the reviewed-side cycle when thread-owl is the reviewer. There is no Copilot watch loop. Entry is triggered by a `queue://review/queue` resource update (via `mcp-resource-subscriber`) or by the presence of existing thread-owl review threads.
+
+Re-review requests are posted as `@thread-owl re-review requested` PR comments — the reviewed-side cycle ends there. The next reviewer-side cycle is triggered by thread-owl's webhook.
+
+> **About this file**
+> `docs/skills/thread-owl-review-cycle.md` is a shared template for this repository.
+> Copy it to your personal AI agent configuration (e.g. `~/.claude/skills/`) before use.
+> Adapt MCP server keys to match your environment.
+
+---
+
+## Setup
+
+### Required MCP Servers
+
+| Server | Role | Reference |
+|--------|------|-----------|
+| `github` | Post PR comments, create issues | [README.md](../../README.md) |
+
+> `review-raven` MCP tools are NOT used in this skill. Thread reading is done via `gh` CLI (GraphQL).
+
+### Placeholder Substitution
+
+| Placeholder | Role | Example |
+|-------------|------|---------|
+| `{GH}` | `github` server tools | `mcp__github__*` |
+
+---
+
+## Overall Flow
+
+```
+Phase 0 (entry + cycles_done recovery)
+  |
+  v
+Phase U2: Collect threads → Phase 3: Classify → Phase 4: Fix → Phase U5: Reply/Resolve
+                                                                          |
+                                                              Phase U6: Cycle evaluation
+                                                                          |
+                                        ┌─────────────────────────────────┘
+                                        ↓ READY_TO_MERGE (need_re_review=no)
+                              Phase 6.5 → Phase 6.6 → Phase 7 → Phase 8
+                                        ↓ ESCALATE (max cycles exceeded)
+                              Phase 6.5 (report) → Phase 7 → Phase 8
+                                        ↓ REQUEST_REREVIEW (cycles_done < max_cycles)
+                              Post @thread-owl comment → reviewed-side cycle complete
+```
+
+---
+
+## Phase 0: Entry & State Recovery
+
+1. Determine `owner`, `repo`, `pr`.
+2. Set `max_cycles = 3` (default; adjust if needed).
+3. Recover `cycles_done` from PR comment history:
+   - Search PR issue comments for `<!-- review-raven: cycles_done=N -->` (most recent occurrence).
+   - If found: `cycles_done = N + 1`.
+   - If not found: `cycles_done = 0`.
+4. Proceed to Phase U2.
+
+## Phase U2: Collect Review Threads
+
+Retrieve all review threads via paginated GraphQL:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            comments(first: 10) {
+              nodes {
+                databaseId
+                body
+                path
+                line
+                author { login }
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner=<owner> -f repo=<repo> -F pr=<pr>
+```
+
+- If `pageInfo.hasNextPage` is `true`, repeat with `-f cursor=<endCursor>` until exhausted.
+- Collect threads where `isResolved = false`.
+- Record each thread's `id` (PRRT node ID — for resolve mutation) and root comment `databaseId` (for replies).
+- If 0 unresolved threads: proceed to **Phase 6.5** with `termination_status = READY_TO_MERGE`.
+- Otherwise: proceed to **Phase 3**.
+
+## Phase 3: Classify & Accept/Reject (Autonomous)
+
+Classify each unresolved comment:
+
+| Class | Criteria |
+|-------|----------|
+| `blocking` | Runtime errors, data integrity violations, security risks, breaking changes, inconsistent published records |
+| `non-blocking` | Recommended but not required: tests, logs, privacy, consistency improvements |
+| `suggestion` | Design, naming, structure, or maintainability suggestions |
+
+Decide `accept` or `reject` autonomously. Reject only with a concrete reason.
+
+**Reject constraint — scope-out / deferred requires a tracking issue.**
+A reject with reason `out-of-scope`, `deferred`, or `follow-up` is NOT complete until traceable to a follow-up issue. The `Follow-up issue` column MUST be filled.
+
+Reject reasons that do NOT require a follow-up issue:
+- `already-handled` — cite the commit / PR / issue.
+- `invalid-premise` — explain the misunderstanding.
+- `wont-fix` — explicit decision; must NOT say "will handle later".
+
+Present this table before editing:
+
+```
+| # | Thread ID | Class | Decision | Summary | Reject reason | Follow-up issue |
+|---|-----------|-------|----------|---------|---------------|-----------------|
+```
+
+Determine `fix_type`:
+
+| fix_type | Use for |
+|----------|---------|
+| `logic` | Code behavior or test-only changes |
+| `spec_change` | Public docs, API, workflow, or compatibility record semantics |
+| `trivial` | Typo, formatting, or wording-only fix |
+| `none` | No accepted changes (all rejected) |
+
+## Phase 4: Fix & Commit
+
+1. Run `git status --short --branch`.
+2. Fix only `accept`-ed items.
+3. Keep changes atomic by review thread unless a shared edit is clearly cleaner.
+4. Re-run build and tests after all fixes.
+5. Make **one commit** covering all fixes (Conventional Commits format).
+6. Push without force unless the user explicitly asks otherwise.
+
+## Phase U5: Reply & Resolve
+
+**Reply** using `{GH}:add_reply_to_pull_request_comment`:
+- `owner`, `repo`, `pull_number`: from Phase 0
+- `comment_id`: root comment's `databaseId` from Phase U2
+- Fixed: mention the commit and concrete fix.
+- Rejected: state the reason clearly (see reject sub-rules below).
+
+**Resolve** using GraphQL mutation:
+
+```bash
+gh api graphql -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { id isResolved }
+    }
+  }
+' -f threadId=<PRRT_node_id>
+```
+
+Always resolve unless a tracking issue cannot be created (see step 4 below).
+
+### Reject reply rules
+
+#### 1. Linking an existing issue
+Include `Tracked by #xxx` or `Follow-up: #xxx`. Confirm the issue actually covers the rejected item.
+
+#### 2. Creating a new follow-up issue
+Call `{GH}:create_issue`. Include `Follow-up: #<number>` in the reply. Record the number in Phase 3 table and Phase 7 summary.
+
+#### 3. Explicit `Won't fix`
+Reply with `Won't fix` and a concrete reason. Do NOT write "will handle later".
+
+#### 4. When issue creation is not possible
+Do NOT resolve the thread. Record as `untracked — needs follow-up issue` in Phase 7.
+
+## Phase U6: Cycle Evaluation & Re-review Decision
+
+**Step 1**: Re-fetch unresolved threads (re-run Phase U2 query).
+- If unresolved > 0: unexpected. Report and stop with `needs user decision`.
+
+**Step 2**: Determine `need_re_review` (only when unresolved = 0):
+
+| fix_type | Accepted `blocking`? | need_re_review |
+|----------|----------------------|----------------|
+| `none` | — | **no** |
+| `trivial` | — | **no** |
+| `logic` or `spec_change` | any | **yes** |
+| any | at least 1 `blocking` | **yes** |
+
+**Step 3**: Route
+
+- `need_re_review = no` → **Phase 6.5** (`termination_status = READY_TO_MERGE`)
+- `need_re_review = yes` AND `cycles_done ≥ max_cycles` → classify termination, proceed to **Phase 6.5**
+- `need_re_review = yes` AND `cycles_done < max_cycles` → post `@thread-owl` comment (see format below), **reviewed-side cycle complete**
+
+### Termination classification
+
+| Classification | Condition | Merge implication |
+|----------------|-----------|-------------------|
+| ✅ `READY_TO_MERGE` | unresolved = 0, need_re_review = no | Safe — normal merge gate |
+| 🟡 `ESCALATE — Clean` | max cycles AND final cycle has **no** `blocking` accepts | Likely safe — note unverified status |
+| 🔴 `ESCALATE — Unverified Fix` | max cycles AND final cycle accepted **≥ 1 `blocking` fix** not re-reviewed | Risky — recommend human review |
+
+Record for Phase 7: `termination_status`, `final_cycle_fix_types`, `unverified_blocking_commits`.
+
+### Re-review request comment format
+
+Post via `{GH}:add_issue_comment`:
+
+```markdown
+@thread-owl re-review requested
+
+The requested changes have been addressed. Please review again.
+
+<!-- review-raven: cycles_done=N -->
+```
+
+Replace `N` with the current value of `cycles_done`. This annotation is used to recover `cycles_done` when the skill re-enters at Phase 0 after the next thread-owl queue notification.
+
+**The reviewed-side cycle ends here. Do NOT loop back to Phase U2.**
+The next reviewer-side cycle is triggered by thread-owl's `issue_comment.created` webhook → queue → mcp-resource-subscriber notification.
+
+---
+
+## Phase 6.5: CI Check
+
+1. Run `gh pr checks <pr>`.
+2. All jobs SUCCESS → Phase 6.6.
+3. Failing jobs: fetch logs with `gh run view <run-id> --log-failed`.
+   - Fixable → add to accept work, return to Phase 4.
+   - Not fixable → report and stop.
+
+If `gh` is unavailable, use `{GH}` / GitHub MCP server to inspect check runs. If neither route works, report `CI: unknown` and stop.
+
+## Phase 6.6: Coverage Check
+
+Check Codecov or similar PR comments if present.
+- If testable coverage gaps exist, return to Phase 4 (`fix_type = logic`).
+- Otherwise continue to Phase 7.
+
+## Phase 7: Summary Comment
+
+Post via `{GH}:add_issue_comment`:
+
+```markdown
+## Review Cycle Summary (thread-owl)
+
+### Changes Made
+- (bulleted overview)
+
+### Accept/Reject Decisions
+- accept: N items
+- reject: M items
+  - Thread <threadId> (PRRT_xxx): (reason)
+
+### Deferred / Scope-out Items
+- None | <list: Thread <threadId> — Follow-up: #N>
+
+### Verification
+- CI: ...
+- Unresolved threads: 0
+- Cycle status: <termination_status>
+  - On `ESCALATE — Unverified Fix`: reason, unverified commit SHA(s), "Recommendation: human review before merge"
+- Final cycle fix types: blocking × N, non-blocking × N, suggestion × N, trivial × N
+- cycles_done: N
+- Re-review: requested via @thread-owl comment | not needed | ESCALATE (max cycles)
+```
+
+**`Deferred / Scope-out Items` rules:** MUST list every `out-of-scope` / `deferred` / `follow-up` reject with follow-up issue number. `- None` only when zero such rejects exist AND no thread was left unresolved.
+
+## Phase 8: Merge Gate
+
+**Never merge autonomously.** Wait for explicit user instruction.
+
+Merge conditions:
+- CI all SUCCESS
+- Unresolved review threads = 0
+- All threads replied
+- No unresolved `blocking` items
+- `termination_status` is `READY_TO_MERGE` or `ESCALATE — Clean`
+
+If `termination_status = ESCALATE — Unverified Fix`:
+1. Do NOT report as ready to merge.
+2. Surface warning with unverified commit SHA(s).
+3. If user still requests merge, confirm they have manually reviewed the unverified blocking fix.
+
+If `termination_status = WAITING_FOR_REVIEW(thread-owl)` (re-review comment posted):
+1. Do NOT report as ready to merge.
+2. Report: "Re-review requested from thread-owl. Waiting for next review cycle."
+
+---
+
+## Notes
+
+- `max_cycles` default is 3. Adjust at Phase 0 if needed.
+- `cycles_done` is recovered from `<!-- review-raven: cycles_done=N -->` PR comment annotation, not from server state.
+- Re-review requests use `@thread-owl` PR comments — NOT `request_copilot_review`.
+- This skill does NOT start Copilot watches or call `get_pr_review_cycle_status`.
+- Fix granularity: atomic per thread (1 thread = 1 logical change unit).
+- Commit strategy: one commit after Phase 4 (Conventional Commits format).
+- Phase 8 requires explicit user instruction.
+
+---
+
+## Tool Reference
+
+| Tool | Purpose |
+|------|---------|
+| `gh` CLI | GraphQL thread collection, resolve mutation, CI checks |
+| `{GH}:add_reply_to_pull_request_comment` | Reply to review thread |
+| `{GH}:add_issue_comment` | Post PR summary / re-review request comment |
+| `{GH}:create_issue` | Create follow-up tracking issue |
+
+---
+
+## See Also
+
+- [`pr-review-cycle`](pr-review-cycle.md) — For Copilot reviews. Uses `request_copilot_review` + async watch loop instead of `@thread-owl` comment.


### PR DESCRIPTION
## Summary

- `docs/skills/pr-review-cycle.md` / `.ja.md`: Copilot review 専用スキルとして明示的にスコープを限定。Phase 6 `REQUEST_REREVIEW` を `request_copilot_review` + watch ループに戻し、スコープ注意書きと See Also セクションを追加
- `docs/skills/thread-owl-review-cycle.md` / `.ja.md`: thread-owl reviewed-side cycle 用の新スキル。GraphQL ページネーション・`cycles_done` アノテーション復元・`@thread-owl re-review requested` コメント投稿（cycle 完了、ループバックなし）を含む
- `CHANGELOG.md` / `.ja.md`: [Unreleased] セクションを ISSUE#71 の内容に更新

Closes #71

## Test plan

- [ ] `pr-review-cycle.md`: スコープ注意書き・Phase 6 の `request_copilot_review` 復元・See Also が正しいことを確認
- [ ] `thread-owl-review-cycle.md`: Phase 0–8 の全フロー・再レビュー依頼フォーマット・cycles_done 復元ロジックを確認
- [ ] CHANGELOG の [Unreleased] セクションに Added / Changed が正しく記述されていることを確認
- [ ] 日本語版が英語版と内容的に対応していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)