### PR TITLE
docs(skills): thread-owl-review-cycle subscriber URI を queue://review/re-review-requests に更新

### DIFF
--- a/docs/skills/thread-owl-review-cycle.ja.md
+++ b/docs/skills/thread-owl-review-cycle.ja.md
@@ -1,6 +1,6 @@
 ---
 name: thread-owl-review-cycle
-description: "thread-owl レビュー用の reviewed-side cycle スキル。thread-owl のレビュースレッドを読み、分類・修正・返信・resolve を行い、再レビューが必要な場合は @thread-owl re-review requested コメントを投稿して cycle を完了する。mcp-resource-subscriber が queue://review/re-review-requests 更新を検知した後、または既存の thread-owl レビュースレッドがある状態で呼び出す。"
+description: "thread-owl レビュー用の reviewed-side cycle スキル。thread-owl のレビュースレッドを読み、分類・修正・返信・resolve を行い、再レビューが必要な場合は @thread-owl re-review requested コメントを投稿して cycle を完了する。thread-owl がレビューを投稿した後（PR に unresolved スレッドが存在する状態）で呼び出す。"
 ---
 
 # thread-owl-review-cycle スキル
@@ -11,11 +11,9 @@ description: "thread-owl レビュー用の reviewed-side cycle スキル。thre
 > このスキルは reviewer が **thread-owl** の場合の reviewed-side cycle を担当する。
 > **Copilot** review（async watch ポーリング）には [`pr-review-cycle`](pr-review-cycle.ja.md) を使うこと。
 
-thread-owl がレビュアーの場合に reviewed-side cycle を実行するスキル。Copilot watch ループはない。エントリーは `mcp-resource-subscriber` による `queue://review/re-review-requests` resource 更新の検知、または既存の thread-owl レビュースレッドの確認によって行う。
+thread-owl がレビュアーの場合に reviewed-side cycle を実行するスキル。Copilot watch ループはない。エントリーは thread-owl が新しいレビューを投稿した後（PR に unresolved な thread-owl スレッドが存在する状態）に行う。thread-owl review の通知を受け取ったらこのスキルを起動すること。
 
-> **Subscriber URI**: `queue://review/queue` ではなく `queue://review/re-review-requests` を使用すること。re-review-requests リソースは `re-review-requested` イベント時のみ通知するため、commit push による `synchronized` webhook が先着しても subscriber が早期終端しない（push-first early termination を防ぐ）。
-
-再レビュー依頼は `@thread-owl re-review requested` PR コメントとして投稿する。reviewed-side cycle はそこで完了し、次の reviewer-side cycle は thread-owl の webhook が起動する。
+再レビュー依頼は `@thread-owl re-review requested` PR コメントとして投稿する。reviewed-side cycle はそこで完了する。thread-owl は自身の `issue_comment.created` webhook でこのコメントを検知し、`re-review-requested` candidate を enqueue して `queue://review/re-review-requests` の subscriber（reviewer-side）に通知する。次の reviewer-side cycle はこの通知で起動する。
 
 > **このファイルについて**
 > `docs/skills/thread-owl-review-cycle.ja.md` はリポジトリ共有用テンプレートです。

--- a/docs/skills/thread-owl-review-cycle.ja.md
+++ b/docs/skills/thread-owl-review-cycle.ja.md
@@ -1,6 +1,6 @@
 ---
 name: thread-owl-review-cycle
-description: "thread-owl レビュー用の reviewed-side cycle スキル。thread-owl のレビュースレッドを読み、分類・修正・返信・resolve を行い、再レビューが必要な場合は @thread-owl re-review requested コメントを投稿して cycle を完了する。mcp-resource-subscriber が queue://review/queue 更新を検知した後、または既存の thread-owl レビュースレッドがある状態で呼び出す。"
+description: "thread-owl レビュー用の reviewed-side cycle スキル。thread-owl のレビュースレッドを読み、分類・修正・返信・resolve を行い、再レビューが必要な場合は @thread-owl re-review requested コメントを投稿して cycle を完了する。mcp-resource-subscriber が queue://review/re-review-requests 更新を検知した後、または既存の thread-owl レビュースレッドがある状態で呼び出す。"
 ---
 
 # thread-owl-review-cycle スキル
@@ -11,7 +11,9 @@ description: "thread-owl レビュー用の reviewed-side cycle スキル。thre
 > このスキルは reviewer が **thread-owl** の場合の reviewed-side cycle を担当する。
 > **Copilot** review（async watch ポーリング）には [`pr-review-cycle`](pr-review-cycle.ja.md) を使うこと。
 
-thread-owl がレビュアーの場合に reviewed-side cycle を実行するスキル。Copilot watch ループはない。エントリーは `mcp-resource-subscriber` による `queue://review/queue` resource 更新の検知、または既存の thread-owl レビュースレッドの確認によって行う。
+thread-owl がレビュアーの場合に reviewed-side cycle を実行するスキル。Copilot watch ループはない。エントリーは `mcp-resource-subscriber` による `queue://review/re-review-requests` resource 更新の検知、または既存の thread-owl レビュースレッドの確認によって行う。
+
+> **Subscriber URI**: `queue://review/queue` ではなく `queue://review/re-review-requests` を使用すること。re-review-requests リソースは `re-review-requested` イベント時のみ通知するため、commit push による `synchronized` webhook が先着しても subscriber が早期終端しない（push-first early termination を防ぐ）。
 
 再レビュー依頼は `@thread-owl re-review requested` PR コメントとして投稿する。reviewed-side cycle はそこで完了し、次の reviewer-side cycle は thread-owl の webhook が起動する。
 

--- a/docs/skills/thread-owl-review-cycle.md
+++ b/docs/skills/thread-owl-review-cycle.md
@@ -1,6 +1,6 @@
 ---
 name: thread-owl-review-cycle
-description: "Reviewed-side cycle for thread-owl reviewers. Reads thread-owl review threads, classifies & fixes, replies, resolves, then posts @thread-owl re-review requested when re-review is needed. Invoke after mcp-resource-subscriber detects a queue://review/queue update, or when existing thread-owl review threads are present."
+description: "Reviewed-side cycle for thread-owl reviewers. Reads thread-owl review threads, classifies & fixes, replies, resolves, then posts @thread-owl re-review requested when re-review is needed. Invoke after mcp-resource-subscriber detects a queue://review/re-review-requests update, or when existing thread-owl review threads are present."
 ---
 
 # thread-owl-review-cycle Skill
@@ -11,7 +11,9 @@ description: "Reviewed-side cycle for thread-owl reviewers. Reads thread-owl rev
 > This skill handles the reviewed-side cycle when the reviewer is **thread-owl**.
 > For **Copilot** reviews (async watch polling), use [`pr-review-cycle`](pr-review-cycle.md) instead.
 
-A skill for the reviewed-side cycle when thread-owl is the reviewer. There is no Copilot watch loop. Entry is triggered by a `queue://review/queue` resource update (via `mcp-resource-subscriber`) or by the presence of existing thread-owl review threads.
+A skill for the reviewed-side cycle when thread-owl is the reviewer. There is no Copilot watch loop. Entry is triggered by a `queue://review/re-review-requests` resource update (via `mcp-resource-subscriber`) or by the presence of existing thread-owl review threads.
+
+> **Subscriber URI**: Use `queue://review/re-review-requests` — NOT `queue://review/queue`. The re-review-requests resource only fires on `re-review-requested` events, preventing the push-first early termination that occurs when `synchronized` arrives before the re-review comment webhook.
 
 Re-review requests are posted as `@thread-owl re-review requested` PR comments — the reviewed-side cycle ends there. The next reviewer-side cycle is triggered by thread-owl's webhook.
 

--- a/docs/skills/thread-owl-review-cycle.md
+++ b/docs/skills/thread-owl-review-cycle.md
@@ -1,6 +1,6 @@
 ---
 name: thread-owl-review-cycle
-description: "Reviewed-side cycle for thread-owl reviewers. Reads thread-owl review threads, classifies & fixes, replies, resolves, then posts @thread-owl re-review requested when re-review is needed. Invoke after mcp-resource-subscriber detects a queue://review/re-review-requests update, or when existing thread-owl review threads are present."
+description: "Reviewed-side cycle for thread-owl reviewers. Reads thread-owl review threads, classifies & fixes, replies, resolves, then posts @thread-owl re-review requested when re-review is needed. Invoke when thread-owl has posted a new review (review threads are present in the PR)."
 ---
 
 # thread-owl-review-cycle Skill
@@ -11,11 +11,9 @@ description: "Reviewed-side cycle for thread-owl reviewers. Reads thread-owl rev
 > This skill handles the reviewed-side cycle when the reviewer is **thread-owl**.
 > For **Copilot** reviews (async watch polling), use [`pr-review-cycle`](pr-review-cycle.md) instead.
 
-A skill for the reviewed-side cycle when thread-owl is the reviewer. There is no Copilot watch loop. Entry is triggered by a `queue://review/re-review-requests` resource update (via `mcp-resource-subscriber`) or by the presence of existing thread-owl review threads.
+A skill for the reviewed-side cycle when thread-owl is the reviewer. There is no Copilot watch loop. Entry is triggered when thread-owl posts a new review (unresolved thread-owl review threads are present in the PR). Invoke this skill after receiving a thread-owl review notification.
 
-> **Subscriber URI**: Use `queue://review/re-review-requests` — NOT `queue://review/queue`. The re-review-requests resource only fires on `re-review-requested` events, preventing the push-first early termination that occurs when `synchronized` arrives before the re-review comment webhook.
-
-Re-review requests are posted as `@thread-owl re-review requested` PR comments — the reviewed-side cycle ends there. The next reviewer-side cycle is triggered by thread-owl's webhook.
+Re-review requests are posted as `@thread-owl re-review requested` PR comments — the reviewed-side cycle ends there. The next reviewer-side cycle is triggered by thread-owl detecting the comment via its `issue_comment.created` webhook, which enqueues a `re-review-requested` candidate and notifies `queue://review/re-review-requests` subscribers (reviewer-side).
 
 > **About this file**
 > `docs/skills/thread-owl-review-cycle.md` is a shared template for this repository.


### PR DESCRIPTION
## Summary

thread-owl PR [scottlz0310/thread-owl#80](https://github.com/scottlz0310/thread-owl/pull/80) が `queue://review/re-review-requests` MCP リソースを追加したことを受け、skill の entry URI を更新する。

- `docs/skills/thread-owl-review-cycle.md` — description + intro を `re-review-requests` URI に更新
- `docs/skills/thread-owl-review-cycle.ja.md` — 同上（日本語版）

## 背景

`queue://review/queue` を購読し続けると、reviewed-side cycle（push → re-review comment の通常経路）で `mcp-resource-subscriber` が `synchronized` 通知により先に終端し、後続の `re-review-requested` 通知を見逃す（push-first early termination）。

`queue://review/re-review-requests` は `re-review-requested` enqueue 時のみ通知するため、この問題を回避できる。

## マージ順序

**thread-owl#80 を先にマージしてから、この PR をマージすること。**  
thread-owl#80 が merge 済みでない状態でこの PR を merge すると、`queue://review/re-review-requests` リソースが存在しない環境でスキルが動作し、subscriber 起動に失敗する。

## Test plan

- [ ] thread-owl#80 が merge 済みであることを確認してから merge する

🤖 Generated with [Claude Code](https://claude.com/claude-code)