### PR TITLE
docs(skills): mcp-resource-subscriber --json モードへの移行 (#74)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -15,6 +15,7 @@
 
 ### 変更
 
+- `docs/skills/pr-review-cycle.md` / `.ja.md` — MCP ポーリング Phase 1 の代替として **Phase 1S**（`mcp-resource-subscriber --json` を使うサブスクリプション方式）を追加。全体フロー図を 2 経路エントリに更新。([Issue #74](https://github.com/scottlz0310/review-raven/issues/74))
 - `docs/skills/pr-review-cycle.md` / `.ja.md` — **Copilot review 専用** スキルとして明示的にスコープを限定。Phase 6 `REQUEST_REREVIEW` を `request_copilot_review` + Copilot watch ループ（当初設計）に戻した。スコープ注意書きと `## 関連スキル`（`thread-owl-review-cycle` へのリンク）を追加。([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
 - `docs/architecture.md` / `.ja.md` — 再レビュー依頼フローのセクションを追加。review-raven（コメント投稿）・thread-owl（webhook → queue）・mcp-resource-subscriber（購読ブリッジ）の責務境界を文書化。([Issue #69](https://github.com/scottlz0310/review-raven/issues/69))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `docs/skills/pr-review-cycle.md` / `.ja.md` — added **Phase 1S** (subscription-based wait using `mcp-resource-subscriber --json`) as an alternative to the MCP polling Phase 1. Updated Overall Flow diagram to reflect the two-path entry. ([Issue #74](https://github.com/scottlz0310/review-raven/issues/74))
 - `docs/skills/pr-review-cycle.md` / `.ja.md` — explicitly scoped to **Copilot review only**. Phase 6 `REQUEST_REREVIEW` reverted to `request_copilot_review` + Copilot watch loop (as originally designed). Added scope callout and `## See Also` link to `thread-owl-review-cycle`. ([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
 - `docs/architecture.md` / `.ja.md` — added Re-review request flow section documenting the responsibility boundary between review-raven (posts comment), thread-owl (webhook → queue), and mcp-resource-subscriber (subscription bridge). ([Issue #69](https://github.com/scottlz0310/review-raven/issues/69))
 

--- a/docs/skills/pr-review-cycle.ja.md
+++ b/docs/skills/pr-review-cycle.ja.md
@@ -46,13 +46,15 @@ MCP ツールのみを使用し、`mcp-resource-subscriber` などのサブス�
 ## 全体フロー
 
 ```
-Phase 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
-                ↑                                              ↓ WAIT / REQUEST_REREVIEW
-                └──────────────────────────────────────────────┘
-                                        ↓ READY_TO_MERGE
-                              Phase 6.5 → Phase 6.6 → Phase 7 → Phase 8
-                                        ↓ ESCALATE
-                                      終了（ユーザーに報告）
+Phase 0 → Phase 1（MCP ポーリング）──┐
+        OR Phase 1S（サブスクリプション）┤
+                                       ↓ Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
+                                Phase 1 ↑                                          ↓ WAIT / REQUEST_REREVIEW
+                                        └──────────────────────────────────────────┘
+                                                            ↓ READY_TO_MERGE
+                                              Phase 6.5 → Phase 6.6 → Phase 7 → Phase 8
+                                                            ↓ ESCALATE
+                                                        終了（ユーザーに報告）
 ```
 
 ---
@@ -104,6 +106,58 @@ Phase 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
 2. `{GH}:add_issue_comment` で以下を投稿:
    `レビュー完了待機がタイムアウトしました（15 分）。手動で再開してください。`
 3. ユーザーに手動再開方法を案内して終了。
+
+## Phase 1S: サブスクリプション方式の待機（mcp-resource-subscriber）
+
+**Phase 1-A/1-B/1-C の代替。** `mcp-resource-subscriber` がインストール済みで MCP watch ポーリングより優先して使う場合に利用する。Phase 1 全体を置き換える。
+
+> `mcp-resource-subscriber` が利用できない環境では Phase 1（ポーリング）の `pr-review-cycle` を使う。
+
+### 1S-B1: サブスクライブ＆待機
+
+```bash
+mcp-resource-subscriber \
+  --url <review-raven MCP URL> \
+  --uri queue://review/queue \
+  --timeout-ms 900000 \
+  --json
+```
+
+stdout を JSON としてパースする。成功時レスポンス:
+
+```json
+{
+  "route": "subscription",
+  "serverUrl": "http://localhost:3000/mcp",
+  "resourceUri": "queue://review/queue",
+  "subscribed": true,
+  "notificationReceived": true,
+  "notificationCount": 1,
+  "errorCode": null,
+  "recommendedNextAction": "READ_REVIEW_THREADS",
+  "finalText": "..."
+}
+```
+
+`json.recommendedNextAction` に従う:
+
+| recommendedNextAction | 対応 |
+|-----------------------|------|
+| `READ_REVIEW_THREADS` | → Phase 2 へ |
+
+### 1S-C: エラー・タイムアウト処理
+
+JSON フィールドから結果を判定する:
+
+| 条件 | 対応 |
+|------|------|
+| `json.route === "timeout" && json.errorCode === "NOTIFICATION_TIMEOUT"` | タイムアウトコメントを投稿してユーザーに手動再開を案内 |
+| `json.errorCode === "SERVER_URL_UNKNOWN"` | サーバー URL の不正を報告してサイクル中断 |
+| `json.errorCode === "INTERNAL_ERROR"` | エラーを報告してサイクル中断 |
+
+失敗時も `json.serverUrl` および `json.resourceUri` は保持される — 診断用にエラー報告に含める。
+
+timeout や error をレビュー完了として扱わない。
 
 ## Phase 2: スレッド取得
 

--- a/docs/skills/pr-review-cycle.md
+++ b/docs/skills/pr-review-cycle.md
@@ -45,13 +45,15 @@ This skill relies only on MCP tools — no `mcp-resource-subscriber` or other su
 ## Overall Flow
 
 ```
-Phase 0 → Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
-                ↑                                              ↓ WAIT / REQUEST_REREVIEW
-                └──────────────────────────────────────────────┘
-                                        ↓ READY_TO_MERGE
-                              Phase 6.5 → Phase 6.6 → Phase 7 → Phase 8
-                                        ↓ ESCALATE
-                              End (report to user)
+Phase 0 → Phase 1 (MCP polling) ──┐
+        OR Phase 1S (subscriber) ─┤
+                                   ↓ Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
+                              Phase 1 ↑                                        ↓ WAIT / REQUEST_REREVIEW
+                                      └────────────────────────────────────────┘
+                                                          ↓ READY_TO_MERGE
+                                            Phase 6.5 → Phase 6.6 → Phase 7 → Phase 8
+                                                          ↓ ESCALATE
+                                                End (report to user)
 ```
 
 ---
@@ -101,6 +103,58 @@ Follow `recommended_next_action`:
 2. Post via `{GH}:add_issue_comment`:
    `Review completion wait timed out after 15 minutes. Please resume manually.`
 3. Guide the user on how to resume manually and exit.
+
+## Phase 1S: Subscription-based Wait (mcp-resource-subscriber)
+
+**Alternative to Phase 1-A/1-B/1-C.** Use when `mcp-resource-subscriber` is installed and preferred over MCP watch polling. Replaces Phase 1 in its entirety.
+
+> Use `pr-review-cycle` (Phase 1 polling) when `mcp-resource-subscriber` is unavailable.
+
+### 1S-B1: Subscribe & Wait
+
+```bash
+mcp-resource-subscriber \
+  --url <review-raven MCP URL> \
+  --uri queue://review/queue \
+  --timeout-ms 900000 \
+  --json
+```
+
+Parse stdout as JSON. Success response:
+
+```json
+{
+  "route": "subscription",
+  "serverUrl": "http://localhost:3000/mcp",
+  "resourceUri": "queue://review/queue",
+  "subscribed": true,
+  "notificationReceived": true,
+  "notificationCount": 1,
+  "errorCode": null,
+  "recommendedNextAction": "READ_REVIEW_THREADS",
+  "finalText": "..."
+}
+```
+
+Follow `json.recommendedNextAction`:
+
+| recommendedNextAction | Action |
+|-----------------------|--------|
+| `READ_REVIEW_THREADS` | → Phase 2 |
+
+### 1S-C: Error & Timeout Handling
+
+Determine outcome from JSON fields:
+
+| Condition | Action |
+|-----------|--------|
+| `json.route === "timeout" && json.errorCode === "NOTIFICATION_TIMEOUT"` | Post timeout comment and guide user to resume manually |
+| `json.errorCode === "SERVER_URL_UNKNOWN"` | Report invalid server URL and abort |
+| `json.errorCode === "INTERNAL_ERROR"` | Report error and abort |
+
+`json.serverUrl` and `json.resourceUri` are preserved even on failure — include them in error reports for diagnostics.
+
+Do not treat timeout or error as review completion.
 
 ## Phase 2: Fetch Threads
 


### PR DESCRIPTION
## Summary

- `docs/skills/pr-review-cycle.md` / `.ja.md` に **Phase 1S**（`mcp-resource-subscriber --json`）セクションを新規追加。MCP ポーリング（Phase 1-A/1-B/1-C）の代替として利用可能
- Phase 1S-B1: `--json` フラグ付き CLI 呼び出し例、JSON レスポンス構造、`json.recommendedNextAction` / `json.errorCode` を使った判定フローを記述
- 全体フロー図を Phase 1（ポーリング）と Phase 1S（サブスクリプション）の 2 経路エントリに更新
- `CHANGELOG.md` / `.ja.md` に変更を記録

**ローカルスキル変更（リポジトリ外・コミット対象外）:**
- `~/.claude/skills/pr-review-subscribe/SKILL.md` を新規作成（Phase 1S を主経路とする standalone スキル）
- `~/.claude/skills/thread-owl-pr-reviewer/SKILL.md` の Queue 契約セクションを `phase-summary route=subscription` line-based パースから `--json` JSON パースに更新

## Acceptance criteria

- [x] `pr-review-cycle.md` / `.ja.md` の Phase 1S-B1 説明が `--json` ベースに更新されている
- [x] line-based パース記述（`phase-summary route=...`、`subscribed true` 等）が除去されている
- [x] `json.route` / `json.errorCode` / `json.recommendedNextAction` を使った判定フローが記述されている
- [x] local skill（`SKILL.md`）も同期されている

## Test plan

- [ ] `docs/skills/pr-review-cycle.md` の Phase 1S セクションに `--json` フラグが含まれている
- [ ] `docs/skills/pr-review-cycle.ja.md` が英語版と同期されている
- [ ] `copilot-review` サーバー名への依存が新規追加ファイルに存在しない

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)