### PR TITLE
feat: Add default auth context fallback for auth=none routes (#80)

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -11,6 +11,8 @@
 
 ### 追加
 
+- `auth=none` ルート向けのデフォルト認証情報とデフォルトユーザー名の動的解決フォールバックを追加: `X-Authenticated-User` および `Authorization` ヘッダーが欠落している場合（`auth=none` プロキシルートなど）に、デフォルト値へフォールバックできるようにしました。`REVIEW_RAVEN_DEFAULT_USER` が明示的に設定されていない場合は、`GITHUB_PERSONAL_ACCESS_TOKEN` を使って GitHub API の `GET /user` を呼び出すことで、トークンの所有者のログイン名を動的に解決してフォールバック値とします。([Issue #80](https://github.com/scottlz0310/review-raven/issues/80))
+
 - `docs/skills/thread-owl-review-cycle.md` / `.ja.md` — thread-owl reviewed-side cycle 用の新 skill を追加。ページネーション付き GraphQL でレビュースレッドを取得し、分類・修正・返信・resolve を行い、再レビューが必要な場合は `@thread-owl re-review requested` コメントを投稿して cycle を完了する。次の reviewer-side cycle は thread-owl webhook が起動する。([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
 
 ### 変更

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Default credentials and dynamic default user resolution for `auth=none` routes: When `X-Authenticated-User` and `Authorization` headers are missing (such as in `auth=none` proxy routes), the server can fall back to default values. The default user is dynamically resolved by calling GitHub's `GET /user` endpoint using the `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable if `REVIEW_RAVEN_DEFAULT_USER` is not explicitly set. ([Issue #80](https://github.com/scottlz0310/review-raven/issues/80))
+
 - `docs/skills/thread-owl-review-cycle.md` / `.ja.md` — new skill for the thread-owl reviewed-side cycle. Reads review threads via paginated GraphQL, classifies and fixes, replies and resolves, then posts `@thread-owl re-review requested` as the re-review path. The reviewed-side cycle ends there; the next reviewer-side cycle is triggered by thread-owl's webhook. ([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
 
 ### Changed

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -38,7 +38,23 @@ func main() {
 
 	slog.Info("auth mode: gateway (trusting X-Authenticated-User header from mcp-gateway)")
 
-	authMiddleware := middleware.Auth()
+	// Resolve default credentials for auth=none fallback (e.g., local development).
+	defaultToken := os.Getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
+	defaultUser := os.Getenv("REVIEW_RAVEN_DEFAULT_USER")
+	if defaultUser == "" && defaultToken != "" {
+		// Try to resolve user login dynamically from GitHub API whoami endpoint.
+		// Use a short timeout so startup is not blocked indefinitely if offline.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if login, err := ghclient.GetAuthenticatedUserLogin(ctx, defaultToken); err == nil {
+			defaultUser = login
+			slog.Info("resolved default user from GitHub API", "login", login)
+		} else {
+			slog.Warn("failed to resolve default user from token", "err", err)
+		}
+		cancel()
+	}
+
+	authMiddleware := middleware.Auth(defaultUser, defaultToken)
 
 	mux := http.NewServeMux()
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -713,3 +713,23 @@ func (c *Client) ResolveThread(ctx context.Context, threadID string) (alreadyRes
 	}
 	return false, nil
 }
+
+// GetAuthenticatedUserLogin fetches the login name of the user authenticated by the token.
+// If the token is empty, returns an error.
+func GetAuthenticatedUserLogin(ctx context.Context, token string) (string, error) {
+	if token == "" {
+		return "", errors.New("token must not be empty")
+	}
+	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	httpClient := oauth2.NewClient(ctx, src)
+	client := github.NewClient(httpClient)
+	user, _, err := client.Users.Get(ctx, "")
+	if err != nil {
+		return "", err
+	}
+	login := user.GetLogin()
+	if login == "" {
+		return "", errors.New("empty login returned from GitHub API")
+	}
+	return login, nil
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -13,17 +13,23 @@ const ContextKeyLogin contextKey = "github_login"
 const ContextKeyToken contextKey = "github_token"
 
 // Auth returns a middleware that trusts the X-Authenticated-User header and
-// Bearer token injected by an upstream proxy (mcp-gateway). Standalone OAuth
-// has been removed; mcp-gateway is required.
-func Auth() func(http.Handler) http.Handler {
+// Bearer token injected by an upstream proxy (mcp-gateway). If headers are missing,
+// it falls back to the provided defaultLogin and defaultToken (useful for auth=none).
+func Auth(defaultLogin, defaultToken string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			login := r.Header.Get("X-Authenticated-User")
+			if login == "" {
+				login = defaultLogin
+			}
 			if login == "" {
 				writeUnauthorized(w, "missing_proxy_identity")
 				return
 			}
 			token := extractBearer(r)
+			if token == "" {
+				token = defaultToken
+			}
 			if token == "" {
 				writeUnauthorized(w, "missing_token")
 				return

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -37,7 +37,74 @@ func TestAuth_TrustProxyHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mw := Auth()
+			mw := Auth("", "")
+
+			var capturedLogin, capturedToken string
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedLogin = LoginFromContext(r.Context())
+				capturedToken = TokenFromContext(r.Context())
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+			if tt.proxyLogin != "" {
+				req.Header.Set("X-Authenticated-User", tt.proxyLogin)
+			}
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			mw(next).ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if tt.wantLogin != "" && capturedLogin != tt.wantLogin {
+				t.Fatalf("login = %q, want %q", capturedLogin, tt.wantLogin)
+			}
+			if capturedToken != tt.wantTokenInCtx {
+				t.Fatalf("token in context = %q, want %q", capturedToken, tt.wantTokenInCtx)
+			}
+		})
+	}
+}
+
+func TestAuth_Fallback(t *testing.T) {
+	tests := []struct {
+		name           string
+		defaultLogin   string
+		defaultToken   string
+		proxyLogin     string
+		authHeader     string
+		wantStatus     int
+		wantLogin      string
+		wantTokenInCtx string
+	}{
+		{
+			name:           "missing headers falls back to default values",
+			defaultLogin:   "default-user",
+			defaultToken:   "default-token",
+			proxyLogin:     "",
+			authHeader:     "",
+			wantStatus:     http.StatusOK,
+			wantLogin:      "default-user",
+			wantTokenInCtx: "default-token",
+		},
+		{
+			name:           "headers take precedence over default values",
+			defaultLogin:   "default-user",
+			defaultToken:   "default-token",
+			proxyLogin:     "override-user",
+			authHeader:     "Bearer override-token",
+			wantStatus:     http.StatusOK,
+			wantLogin:      "override-user",
+			wantTokenInCtx: "override-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mw := Auth(tt.defaultLogin, tt.defaultToken)
 
 			var capturedLogin, capturedToken string
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes #80

## Summary

- `Auth()` ミドルウェアに `defaultLogin` / `defaultToken` パラメータを追加し、`X-Authenticated-User` / `Authorization` ヘッダーが欠落している場合（`auth=none` プロキシルートなど）にデフォルト値へフォールバックできるようにした
- `REVIEW_RAVEN_DEFAULT_USER` が未設定かつ `GITHUB_PERSONAL_ACCESS_TOKEN` が存在する場合、起動時に GitHub API `GET /user` を呼び出してトークン所有者のログイン名を動的解決する（5秒タイムアウト付き）
- `GetAuthenticatedUserLogin(ctx, token)` を `internal/github/client.go` に追加
- `TestAuth_Fallback` テストを追加（デフォルト値へのフォールバックと、ヘッダーが優先されることを検証）

## Test plan

- [ ] `go test ./internal/middleware/...` — `TestAuth_TrustProxyHeaders` / `TestAuth_Fallback` が通ること
- [ ] `REVIEW_RAVEN_DEFAULT_USER` 未設定・`GITHUB_PERSONAL_ACCESS_TOKEN` 設定済みの状態でサーバーを起動し、ログに `resolved default user from GitHub API` が出ること
- [ ] `REVIEW_RAVEN_DEFAULT_USER` を明示設定した場合は API 呼び出しが行われないこと（ログに `resolved default user` が出ないこと）
- [ ] ヘッダーあり / なし 両方のリクエストで認証が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)