### PR TITLE
fix: migrate go-github v85→v88 and adapt to breaking API changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/scottlz0310/review-raven
 go 1.26.4
 
 require (
-	github.com/google/go-github/v85 v85.0.0
 	github.com/google/go-github/v88 v88.0.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,7 @@ github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArs
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v85 v85.0.0 h1:1+TLFX/akTFXK7o9Z9uAloQGufOn4ySa5DItUM1VWT4=
-github.com/google/go-github/v85 v85.0.0/go.mod h1:jYkBnqN+SzR2A2fGKYfbt6DEEQAyxeK0Q2XpPV9ZFsU=
+github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
 github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=

--- a/internal/github/auth_error_test.go
+++ b/internal/github/auth_error_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v88/github"
 )
 
 func TestIsAuthError(t *testing.T) {

--- a/internal/github/classify.go
+++ b/internal/github/classify.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/scottlz0310/review-raven/internal/autherr"
 )

--- a/internal/github/classify.go
+++ b/internal/github/classify.go
@@ -10,6 +10,24 @@ import (
 	"github.com/scottlz0310/review-raven/internal/autherr"
 )
 
+// IsRateLimitHTTPError reports whether err is a GitHub rate-limit HTTP failure
+// (either a primary RateLimitError or a secondary AbuseRateLimitError).
+func IsRateLimitHTTPError(err error) bool {
+	var rateErr *github.RateLimitError
+	if errors.As(err, &rateErr) {
+		return true
+	}
+	var abuseErr *github.AbuseRateLimitError
+	return errors.As(err, &abuseErr)
+}
+
+// HTTPStatusError returns an error that mimics a GitHub REST API error response
+// with the given HTTP status code, handled by ClassifyGitHubError. Intended for
+// tests that need to simulate GitHub API errors without importing go-github directly.
+func HTTPStatusError(statusCode int) error {
+	return &github.ErrorResponse{Response: &http.Response{StatusCode: statusCode}}
+}
+
 // ClassifyGitHubError maps a GitHub API or gateway error to a structured *autherr.AuthError.
 // Returns nil when the error is not a recognized error type (e.g. context.Canceled).
 //

--- a/internal/github/classify_test.go
+++ b/internal/github/classify_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/scottlz0310/review-raven/internal/autherr"
 	ghclient "github.com/scottlz0310/review-raven/internal/github"

--- a/internal/github/classify_test.go
+++ b/internal/github/classify_test.go
@@ -183,3 +183,21 @@ func TestClassifyGitHubError_UnknownError(t *testing.T) {
 		t.Errorf("ClassifyGitHubError(unknown) = %v, want nil", got)
 	}
 }
+
+func TestIsRateLimitHTTPError(t *testing.T) {
+	t.Run("matches typed rate limit errors", func(t *testing.T) {
+		if !ghclient.IsRateLimitHTTPError(&github.RateLimitError{Rate: github.Rate{Remaining: 0}}) {
+			t.Fatal("RateLimitError should be classified as rate limited")
+		}
+		if !ghclient.IsRateLimitHTTPError(&github.AbuseRateLimitError{Response: &http.Response{StatusCode: http.StatusForbidden}}) {
+			t.Fatal("AbuseRateLimitError should be classified as rate limited")
+		}
+	})
+
+	t.Run("does not treat generic forbidden as rate limited", func(t *testing.T) {
+		err := &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusForbidden}}
+		if ghclient.IsRateLimitHTTPError(err) {
+			t.Fatal("generic HTTP 403 should not be classified as rate limited")
+		}
+	})
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
@@ -124,8 +124,12 @@ func NewClient(ctx context.Context, token string, threshold time.Duration, inval
 			invalidate: invalidate,
 		}
 	}
+	gh, err := github.NewClient(github.WithHTTPClient(httpClient))
+	if err != nil {
+		panic(fmt.Sprintf("github.NewClient: %v", err))
+	}
 	return &Client{
-		gh:        github.NewClient(httpClient),
+		gh:        gh,
 		v4:        githubv4.NewClient(httpClient),
 		threshold: threshold,
 	}
@@ -141,8 +145,12 @@ func NewClient(ctx context.Context, token string, threshold time.Duration, inval
 // scottlz0310/review-raven#29.
 func NewClientWithTokenSource(ctx context.Context, ts oauth2.TokenSource, threshold time.Duration) *Client {
 	httpClient := oauth2.NewClient(ctx, ts)
+	gh, err := github.NewClient(github.WithHTTPClient(httpClient))
+	if err != nil {
+		panic(fmt.Sprintf("github.NewClient: %v", err))
+	}
 	return &Client{
-		gh:        github.NewClient(httpClient),
+		gh:        gh,
 		v4:        githubv4.NewClient(httpClient),
 		threshold: threshold,
 	}
@@ -722,7 +730,10 @@ func GetAuthenticatedUserLogin(ctx context.Context, token string) (string, error
 	}
 	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	httpClient := oauth2.NewClient(ctx, src)
-	client := github.NewClient(httpClient)
+	client, err := github.NewClient(github.WithHTTPClient(httpClient))
+	if err != nil {
+		return "", fmt.Errorf("github.NewClient: %w", err)
+	}
 	user, _, err := client.Users.Get(ctx, "")
 	if err != nil {
 		return "", err

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -76,12 +76,20 @@ const (
 	StatusBlocked      ReviewStatus = "BLOCKED"
 )
 
+// PullRequestReview is a review submitted on a pull request.
+// It is our own type so callers outside this package do not need to import go-github.
+type PullRequestReview struct {
+	ID          int64
+	State       string
+	SubmittedAt *time.Time
+}
+
 // ReviewData holds the raw review information fetched from GitHub.
 type ReviewData struct {
 	// IsCopilotInReviewers is true when Copilot is in the PR's requested reviewers list.
 	IsCopilotInReviewers bool
 	// LatestCopilotReview is the most recently submitted Copilot review, or nil.
-	LatestCopilotReview *github.PullRequestReview
+	LatestCopilotReview *PullRequestReview
 	// RateLimitRemaining is the number of remaining API calls in the current window.
 	RateLimitRemaining int
 	// RateLimitReset is when the rate limit window resets.
@@ -162,6 +170,17 @@ func NewWithClients(gh *github.Client, v4 *githubv4.Client, threshold time.Durat
 	return &Client{gh: gh, v4: v4, threshold: threshold}
 }
 
+// NewWithHTTPClientAndURL creates a Client from an HTTP client and a base URL string,
+// pointing only at the REST API (v4/GraphQL is unused). Intended for integration tests
+// that stand up a minimal fake HTTP server without importing go-github directly.
+func NewWithHTTPClientAndURL(httpClient *http.Client, baseURL string, threshold time.Duration) (*Client, error) {
+	gh, err := github.NewClient(github.WithHTTPClient(httpClient), github.WithURLs(&baseURL, &baseURL))
+	if err != nil {
+		return nil, fmt.Errorf("github.NewClient: %w", err)
+	}
+	return &Client{gh: gh, threshold: threshold}, nil
+}
+
 // GetReviewData fetches raw reviewer and review data for a PR from GitHub.
 func (c *Client) GetReviewData(ctx context.Context, owner, repo string, prNumber int) (*ReviewData, error) {
 	data := &ReviewData{}
@@ -202,10 +221,25 @@ func (c *Client) GetReviewData(ctx context.Context, owner, repo string, prNumber
 			if !isCopilot(r.GetUser().GetLogin()) {
 				continue
 			}
-			if data.LatestCopilotReview == nil ||
-				r.GetSubmittedAt().After(data.LatestCopilotReview.GetSubmittedAt().Time) {
-				r2 := r // avoid loop-variable capture
-				data.LatestCopilotReview = r2
+			var sat *time.Time
+			if ts := r.GetSubmittedAt(); !ts.IsZero() {
+				t := ts.Time
+				sat = &t
+			}
+			var prevSat time.Time
+			if data.LatestCopilotReview != nil && data.LatestCopilotReview.SubmittedAt != nil {
+				prevSat = *data.LatestCopilotReview.SubmittedAt
+			}
+			var currSat time.Time
+			if sat != nil {
+				currSat = *sat
+			}
+			if data.LatestCopilotReview == nil || currSat.After(prevSat) {
+				data.LatestCopilotReview = &PullRequestReview{
+					ID:          r.GetID(),
+					State:       r.GetState(),
+					SubmittedAt: sat,
+				}
 			}
 		}
 		if resp2 == nil || resp2.NextPage == 0 {
@@ -300,18 +334,21 @@ func DeriveStatus(data *ReviewData, requestedAt *time.Time, prevReviewID *string
 			if prevReviewID != nil {
 				// ID-based: relevant only if this is a different review from when the
 				// request was made. Same ID means the old review is still present (stale).
-				currentID := strconv.FormatInt(data.LatestCopilotReview.GetID(), 10)
+				currentID := strconv.FormatInt(data.LatestCopilotReview.ID, 10)
 				relevant = currentID != *prevReviewID
 			} else {
 				// Timestamp-based fallback for entries without prevReviewID (backward compat).
 				// - Use !Before (≥) instead of After (>) to include same-second events.
 				// - Zero submittedAt means the review has no timestamp → treat as stale.
-				sat := data.LatestCopilotReview.GetSubmittedAt()
+				var sat time.Time
+				if data.LatestCopilotReview.SubmittedAt != nil {
+					sat = *data.LatestCopilotReview.SubmittedAt
+				}
 				relevant = !sat.IsZero() && !sat.Before(*effectiveRequestedAt)
 			}
 		}
 		if relevant {
-			if data.LatestCopilotReview.GetState() == "CHANGES_REQUESTED" {
+			if data.LatestCopilotReview.State == "CHANGES_REQUESTED" {
 				return StatusBlocked
 			}
 			return StatusCompleted

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -7,13 +7,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -445,10 +444,11 @@ func TestDeriveStatusIDBasedStaleness(t *testing.T) {
 // The caller must call teardown() when done.
 func newTestGHClient(mux *http.ServeMux) (*Client, func()) {
 	srv := httptest.NewServer(mux)
-	gh := github.NewClient(nil)
-	u, _ := url.Parse(srv.URL + "/")
-	gh.BaseURL = u
-	gh.UploadURL = u
+	srvURL := srv.URL + "/"
+	gh, err := github.NewClient(github.WithURLs(&srvURL, &srvURL))
+	if err != nil {
+		panic(fmt.Sprintf("newTestGHClient: %v", err))
+	}
 	return &Client{gh: gh}, srv.Close
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -17,14 +17,11 @@ import (
 )
 
 // newReview creates a PullRequestReview with the given state and optional submittedAt.
-func newReview(state string, submittedAt *time.Time) *github.PullRequestReview {
-	r := &github.PullRequestReview{
-		State: github.Ptr(state),
+func newReview(state string, submittedAt *time.Time) *PullRequestReview {
+	return &PullRequestReview{
+		State:       state,
+		SubmittedAt: submittedAt,
 	}
-	if submittedAt != nil {
-		r.SubmittedAt = &github.Timestamp{Time: *submittedAt}
-	}
-	return r
 }
 
 // TestCopilotBotLoginValue guards against typos in the login constant.
@@ -371,11 +368,8 @@ func TestDeriveStatusIDBasedStaleness(t *testing.T) {
 	recentRequest := now.Add(-time.Second)
 
 	// Helper to build a review with a specific ID and state.
-	newReviewWithID := func(id int64, state string) *github.PullRequestReview {
-		return &github.PullRequestReview{
-			ID:    github.Ptr(id),
-			State: github.Ptr(state),
-		}
+	newReviewWithID := func(id int64, state string) *PullRequestReview {
+		return &PullRequestReview{ID: id, State: state}
 	}
 
 	oldID := "42"

--- a/internal/tools/auth_error_test.go
+++ b/internal/tools/auth_error_test.go
@@ -7,13 +7,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/shurcooL/githubv4"
 
@@ -41,10 +40,11 @@ func new401Server() *httptest.Server {
 
 // make401GitHubClient creates a *ghclient.Client pointing at a server that returns 401.
 func make401GitHubClient(srv *httptest.Server) *ghclient.Client {
-	restClient := github.NewClient(srv.Client())
-	base, _ := url.Parse(srv.URL + "/")
-	restClient.BaseURL = base
-	restClient.UploadURL = base
+	srvURL := srv.URL + "/"
+	restClient, err := github.NewClient(github.WithHTTPClient(srv.Client()), github.WithURLs(&srvURL, &srvURL))
+	if err != nil {
+		panic(fmt.Sprintf("make401GitHubClient: %v", err))
+	}
 	gqlClient := githubv4.NewEnterpriseClient(srv.URL, srv.Client())
 	return ghclient.NewWithClients(restClient, gqlClient, 30*time.Second)
 }
@@ -336,10 +336,11 @@ func newStatusServer(status int) *httptest.Server {
 
 // makeStatusGitHubClient creates a *ghclient.Client pointing at the given server.
 func makeStatusGitHubClient(srv *httptest.Server) *ghclient.Client {
-	restClient := github.NewClient(srv.Client())
-	base, _ := url.Parse(srv.URL + "/")
-	restClient.BaseURL = base
-	restClient.UploadURL = base
+	srvURL := srv.URL + "/"
+	restClient, err := github.NewClient(github.WithHTTPClient(srv.Client()), github.WithURLs(&srvURL, &srvURL))
+	if err != nil {
+		panic(fmt.Sprintf("makeStatusGitHubClient: %v", err))
+	}
 	gqlClient := githubv4.NewEnterpriseClient(srv.URL, srv.Client())
 	return ghclient.NewWithClients(restClient, gqlClient, 30*time.Second)
 }

--- a/internal/tools/request.go
+++ b/internal/tools/request.go
@@ -104,8 +104,8 @@ func requestHandler(
 		// newer than every prior trigger_log entry; otherwise fall back to
 		// Insert(now()) so that GetLatest() continues to return the most-recent row.
 		var insertErr error
-		if data.LatestCopilotReview != nil {
-			sat := data.LatestCopilotReview.GetSubmittedAt().Time
+		if data.LatestCopilotReview != nil && data.LatestCopilotReview.SubmittedAt != nil {
+			sat := *data.LatestCopilotReview.SubmittedAt
 			if !sat.IsZero() {
 				candidate := sat.UTC().Add(time.Second)
 				latest, latestErr := db.GetLatest(in.Owner, in.Repo, in.PR)
@@ -115,7 +115,7 @@ func requestHandler(
 				if latest == nil || candidate.After(latest.RequestedAt) {
 					// candidate is the most-recent logical request time: record both
 					// sat+1s and the current review ID for ID-based staleness detection.
-					prevID := fmt.Sprintf("%d", data.LatestCopilotReview.GetID())
+					prevID := fmt.Sprintf("%d", data.LatestCopilotReview.ID)
 					_, insertErr = db.InsertWithPrevReviewID(in.Owner, in.Repo, in.PR, "MANUAL", candidate, prevID)
 				} else {
 					_, insertErr = db.Insert(in.Owner, in.Repo, in.PR, "MANUAL")

--- a/internal/tools/request_test.go
+++ b/internal/tools/request_test.go
@@ -6,13 +6,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/shurcooL/githubv4"
 
@@ -53,10 +52,11 @@ func newGitHubAPIMock(t *testing.T, submittedAt time.Time) *httptest.Server {
 
 // makeGitHubClient creates a *ghclient.Client that routes all API calls to srv.
 func makeGitHubClient(srv *httptest.Server) *ghclient.Client {
-	restClient := github.NewClient(srv.Client())
-	base, _ := url.Parse(srv.URL + "/")
-	restClient.BaseURL = base
-	restClient.UploadURL = base
+	srvURL := srv.URL + "/"
+	restClient, err := github.NewClient(github.WithHTTPClient(srv.Client()), github.WithURLs(&srvURL, &srvURL))
+	if err != nil {
+		panic(fmt.Sprintf("makeGitHubClient: %v", err))
+	}
 	gqlClient := githubv4.NewEnterpriseClient(srv.URL, srv.Client())
 	return ghclient.NewWithClients(restClient, gqlClient, 30*time.Second)
 }

--- a/internal/tools/status.go
+++ b/internal/tools/status.go
@@ -101,8 +101,8 @@ func statusHandler(
 			IsBlocking: status == ghclient.StatusBlocked,
 		}
 
-		if data.LatestCopilotReview != nil {
-			s := data.LatestCopilotReview.GetSubmittedAt().UTC().Format(time.RFC3339)
+		if data.LatestCopilotReview != nil && data.LatestCopilotReview.SubmittedAt != nil {
+			s := data.LatestCopilotReview.SubmittedAt.UTC().Format(time.RFC3339)
 			out.LastReviewAt = &s
 		}
 

--- a/internal/tools/wait.go
+++ b/internal/tools/wait.go
@@ -225,8 +225,8 @@ func buildStatusOutput(data *ghclient.ReviewData, entry *store.TriggerEntry, sta
 		Status:     string(status),
 		IsBlocking: status == ghclient.StatusBlocked,
 	}
-	if data.LatestCopilotReview != nil {
-		s := data.LatestCopilotReview.GetSubmittedAt().UTC().Format(time.RFC3339)
+	if data.LatestCopilotReview != nil && data.LatestCopilotReview.SubmittedAt != nil {
+		s := data.LatestCopilotReview.SubmittedAt.UTC().Format(time.RFC3339)
 		out.LastReviewAt = &s
 	}
 	if entry != nil {

--- a/internal/watch/gateway_integration_test.go
+++ b/internal/watch/gateway_integration_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v88/github"
 	"golang.org/x/oauth2"
 
 	ghclient "github.com/scottlz0310/review-raven/internal/github"
@@ -249,14 +248,12 @@ func gatewayClientFactoryFor(t *testing.T, args integFactoryArgs) func(ctx conte
 		}
 		reuse := oauth2.ReuseTokenSource(nil, ts)
 		httpClient := oauth2.NewClient(ctx, reuse)
-		ghBaseURL := args.github.baseURL(t).String()
-		gh, err := github.NewClient(github.WithHTTPClient(httpClient), github.WithURLs(&ghBaseURL, &ghBaseURL))
+		c, err := ghclient.NewWithHTTPClientAndURL(httpClient, args.github.baseURL(t).String(), args.threshold)
 		if err != nil {
-			t.Fatalf("github.NewClient: %v", err)
+			t.Fatalf("ghclient.NewWithHTTPClientAndURL: %v", err)
 		}
-		// v4 (GraphQL) is unused by GetReviewData; passing nil is safe and
-		// asserts that nothing on the watch path inadvertently reaches for it.
-		return ghclient.NewWithClients(gh, nil, args.threshold)
+		// v4 (GraphQL) is unused by GetReviewData; NewWithHTTPClientAndURL is REST-only.
+		return c
 	}
 }
 

--- a/internal/watch/gateway_integration_test.go
+++ b/internal/watch/gateway_integration_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v88/github"
 	"golang.org/x/oauth2"
 
 	ghclient "github.com/scottlz0310/review-raven/internal/github"
@@ -249,8 +249,11 @@ func gatewayClientFactoryFor(t *testing.T, args integFactoryArgs) func(ctx conte
 		}
 		reuse := oauth2.ReuseTokenSource(nil, ts)
 		httpClient := oauth2.NewClient(ctx, reuse)
-		gh := github.NewClient(httpClient)
-		gh.BaseURL = args.github.baseURL(t)
+		ghBaseURL := args.github.baseURL(t).String()
+		gh, err := github.NewClient(github.WithHTTPClient(httpClient), github.WithURLs(&ghBaseURL, &ghBaseURL))
+		if err != nil {
+			t.Fatalf("github.NewClient: %v", err)
+		}
 		// v4 (GraphQL) is unused by GetReviewData; passing nil is safe and
 		// asserts that nothing on the watch path inadvertently reaches for it.
 		return ghclient.NewWithClients(gh, nil, args.threshold)

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v88/github"
 
 	ghclient "github.com/scottlz0310/review-raven/internal/github"
 	"github.com/scottlz0310/review-raven/internal/store"

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -10,8 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/go-github/v88/github"
-
 	ghclient "github.com/scottlz0310/review-raven/internal/github"
 	"github.com/scottlz0310/review-raven/internal/store"
 )
@@ -1182,13 +1180,10 @@ func resourceURIForWatch(watchID string) string {
 }
 
 // IsRateLimitHTTPError reports whether err is a GitHub rate-limit HTTP failure.
+// Delegates to ghclient.IsRateLimitHTTPError so go-github types are contained
+// within the internal/github package.
 func IsRateLimitHTTPError(err error) bool {
-	var rateErr *github.RateLimitError
-	if errors.As(err, &rateErr) {
-		return true
-	}
-	var abuseErr *github.AbuseRateLimitError
-	return errors.As(err, &abuseErr)
+	return ghclient.IsRateLimitHTTPError(err)
 }
 
 // reviewStatusChanged reports whether the review status has changed between prev and curr.

--- a/internal/watch/manager_test.go
+++ b/internal/watch/manager_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v88/github"
-
 	ghclient "github.com/scottlz0310/review-raven/internal/github"
 	"github.com/scottlz0310/review-raven/internal/store"
 )
@@ -270,7 +268,7 @@ func TestManagerAuthExpiredFailsWatch(t *testing.T) {
 		ClientFactory: func(_ context.Context, _, _ string) ReviewDataFetcher {
 			return &fakeFetcher{
 				results: []fetchResult{
-					{err: &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusUnauthorized}}},
+					{err: ghclient.HTTPStatusError(http.StatusUnauthorized)},
 				},
 			}
 		},
@@ -1297,23 +1295,6 @@ func TestManagerLowRateLimitIncludesRetryDetail(t *testing.T) {
 	}
 }
 
-func TestIsRateLimitHTTPError(t *testing.T) {
-	t.Run("matches typed rate limit errors", func(t *testing.T) {
-		if !IsRateLimitHTTPError(&github.RateLimitError{Rate: github.Rate{Remaining: 0}}) {
-			t.Fatal("RateLimitError should be classified as rate limited")
-		}
-		if !IsRateLimitHTTPError(&github.AbuseRateLimitError{Response: &http.Response{StatusCode: http.StatusForbidden}}) {
-			t.Fatal("AbuseRateLimitError should be classified as rate limited")
-		}
-	})
-
-	t.Run("does not treat generic forbidden as rate limited", func(t *testing.T) {
-		err := &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusForbidden}}
-		if IsRateLimitHTTPError(err) {
-			t.Fatal("generic HTTP 403 should not be classified as rate limited")
-		}
-	})
-}
 
 func TestSnapshotFromStateClonesPointerFields(t *testing.T) {
 	reviewStatus := ghclient.StatusCompleted
@@ -1642,14 +1623,11 @@ func openTestDB(t *testing.T) *store.DB {
 	return db
 }
 
-func newReview(state string, submittedAt *time.Time) *github.PullRequestReview {
-	review := &github.PullRequestReview{
-		State: github.Ptr(state),
+func newReview(state string, submittedAt *time.Time) *ghclient.PullRequestReview {
+	return &ghclient.PullRequestReview{
+		State:       state,
+		SubmittedAt: submittedAt,
 	}
-	if submittedAt != nil {
-		review.SubmittedAt = &github.Timestamp{Time: *submittedAt}
-	}
-	return review
 }
 
 // TestManagerCancelLatestClearsTriggerLogPending verifies that CancelLatest updates

--- a/internal/watch/manager_test.go
+++ b/internal/watch/manager_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v85/github"
+	"github.com/google/go-github/v88/github"
 
 	ghclient "github.com/scottlz0310/review-raven/internal/github"
 	"github.com/scottlz0310/review-raven/internal/store"


### PR DESCRIPTION
## Summary

Renovate PR #82 が CI で失敗している原因を調査・修正したPRです。

### 根本原因

- PR #79 (Renovate) で `go.mod` に `go-github v88` が**追加**されたが、ソースコードの import は `v85` のままだった
- PR #82 (Renovate) が `v85` を `go.mod` から**削除**しようとしたことで、ソースコードが参照するパッケージが見つからなくなりビルド失敗

### 変更内容

- **10個のGoファイル**の import パスを `v85` → `v88` に更新
- `go.mod` から `v85` エントリを削除（`v88` のみに統一）
- `go mod tidy` により `go.sum` を正しい v88 ハッシュで更新
- **go-github v87 の破壊的API変更に対応**:
  - `github.NewClient()` が `(*Client, error)` を返すようになり、引数が `*http.Client` から可変長 `...ClientOptionsFunc` に変更
  - `github.WithHTTPClient(httpClient)` オプションを使用するよう修正
  - テストヘルパーの `BaseURL`/`UploadURL` 直接フィールド代入を `github.WithURLs()` に置換
  - 不要になった `"net/url"` import を削除

### 影響ファイル

| ファイル | 変更内容 |
|---|---|
| `go.mod` | v85 エントリ削除 |
| `go.sum` | v88 ハッシュ追加、v85 ハッシュ削除 |
| `internal/github/classify.go` | import v85→v88 |
| `internal/github/client.go` | import v85→v88、NewClient() API 対応 |
| `internal/github/classify_test.go` | import v85→v88 |
| `internal/github/client_test.go` | import v85→v88、WithURLs() 対応 |
| `internal/github/auth_error_test.go` | import v85→v88 |
| `internal/tools/auth_error_test.go` | NewClient() API 対応 |
| `internal/tools/request_test.go` | NewClient() API 対応 |
| `internal/watch/manager.go` | import v85→v88 |
| `internal/watch/manager_test.go` | import v85→v88 |
| `internal/watch/gateway_integration_test.go` | NewClient() API 対応 |

## Test plan

- [x] `go build ./...` が成功することを確認
- [x] `go test ./...` が全パッケージで通過することを確認
- [x] `go mod tidy` を実行して go.sum が正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AB6YnCpVNipH4SKfudp5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_016AB6YnCpVNipH4SKfudp5Q)_