### PR TITLE
feat: PERMISSION_DENIED 切り分け用に diagnose_github_token ツールを追加

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -11,6 +11,8 @@
 
 ### 追加
 
+- `diagnose_github_token` MCP tool を追加 — 現在のリクエストで使われているトークンの login と OAuth スコープ(GitHub `GET /user` の `X-OAuth-Scopes` レスポンスヘッダーから解析)を返す。トークン生値は返さない。read 系操作は成功するのに write 系操作(`reply_and_resolve_review_thread` 等)がトークンのスコープ不足で `PERMISSION_DENIED` になるケースの原因切り分け用。([Issue #89](https://github.com/scottlz0310/review-raven/issues/89))
+
 - `spike-request-scoped-reauth.md` / `.ja.md` — `get_review_threads` 等のリクエストスコープ（非 watch）tool call で `REAUTH_REQUIRED` が頻発する問題の spike 調査結果。根本原因は mcp-gateway builtin mode が token 交換時に GitHub provider アクセストークンを破棄するため、`EnsureFreshAccessTokenForSubject` が gateway RS256 JWT を Bearer として review-raven に渡し、GitHub が毎回 401 を返すこと。修正は mcp-gateway 側に帰属（[mcp-gateway#188](https://github.com/scottlz0310/mcp-gateway/issues/188) として起票済み）。review-raven 側のコード修正は不要。([Issue #87](https://github.com/scottlz0310/review-raven/issues/87))
 
 - `auth=none` ルート向けのデフォルト認証情報とデフォルトユーザー名の動的解決フォールバックを追加: `X-Authenticated-User` および `Authorization` ヘッダーが欠落している場合（`auth=none` プロキシルートなど）に、デフォルト値へフォールバックできるようにしました。`REVIEW_RAVEN_DEFAULT_USER` が明示的に設定されていない場合は、`GITHUB_PERSONAL_ACCESS_TOKEN` を使って GitHub API の `GET /user` を呼び出すことで、トークンの所有者のログイン名を動的に解決してフォールバック値とします。([Issue #80](https://github.com/scottlz0310/review-raven/issues/80))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `diagnose_github_token` MCP tool — reports the current request's token login and OAuth scopes (parsed from GitHub's `X-OAuth-Scopes` response header on `GET /user`), without ever returning the raw token. Added to help diagnose cases where read operations succeed but a write operation (e.g. `reply_and_resolve_review_thread`) fails with `PERMISSION_DENIED` due to insufficient token scope. ([Issue #89](https://github.com/scottlz0310/review-raven/issues/89))
+
 - `spike-request-scoped-reauth.md` / `.ja.md` — spike investigation into frequent `REAUTH_REQUIRED` on request-scoped (non-watch) tool calls such as `get_review_threads`. Root cause: mcp-gateway builtin mode discards the GitHub provider access token at token exchange, so `EnsureFreshAccessTokenForSubject` hands the gateway RS256 JWT to review-raven as the Bearer token and GitHub rejects it with 401 on every call. Fix belongs to mcp-gateway (filed as [mcp-gateway#188](https://github.com/scottlz0310/mcp-gateway/issues/188)); no review-raven code change required. ([Issue #87](https://github.com/scottlz0310/review-raven/issues/87))
 
 - Default credentials and dynamic default user resolution for `auth=none` routes: When `X-Authenticated-User` and `Authorization` headers are missing (such as in `auth=none` proxy routes), the server can fall back to default values. The default user is dynamically resolved by calling GitHub's `GET /user` endpoint using the `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable if `REVIEW_RAVEN_DEFAULT_USER` is not explicitly set. ([Issue #80](https://github.com/scottlz0310/review-raven/issues/80))

--- a/README.ja.md
+++ b/README.ja.md
@@ -35,6 +35,7 @@ PR レビューを受けて直す側の MCP（Model Context Protocol）サーバ
 | `resolve_review_thread` | スレッドを解決済みにする |
 | `reply_and_resolve_review_thread` | 返信→解決を順次実行 |
 | `wait_for_copilot_review` | legacy blocking wait（fallback） |
+| `diagnose_github_token` | 現在のトークンの login と OAuth スコープ(`X-OAuth-Scopes` レスポンスヘッダー由来)を返す。`PERMISSION_DENIED` の原因切り分け用 |
 
 セットアップと運用は [docs/usage.ja.md](docs/usage.ja.md) を参照。ツール単位の詳細は [docs/watch-tools.ja.md](docs/watch-tools.ja.md) と [docs/skills/pr-review-cycle.ja.md](docs/skills/pr-review-cycle.ja.md) を参照。アーキテクチャおよび Thread Owl・mcp-resource-subscriber との責務境界は [docs/architecture.ja.md](docs/architecture.ja.md) を参照。
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ An MCP (Model Context Protocol) server for the **reviewed side** of a PR review 
 | `resolve_review_thread` | Mark a thread as resolved |
 | `reply_and_resolve_review_thread` | Reply then resolve in sequence |
 | `wait_for_copilot_review` | Legacy blocking wait (fallback) |
+| `diagnose_github_token` | Report the current token's login and OAuth scopes (from the `X-OAuth-Scopes` response header) for diagnosing `PERMISSION_DENIED` failures |
 
 See [docs/usage.md](docs/usage.md) for setup and operation. Tool-level details are in [docs/watch-tools.md](docs/watch-tools.md) and [docs/skills/pr-review-cycle.md](docs/skills/pr-review-cycle.md). For the architecture and responsibility boundaries with Thread Owl and mcp-resource-subscriber, see [docs/architecture.md](docs/architecture.md).
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -762,22 +762,60 @@ func (c *Client) ResolveThread(ctx context.Context, threadID string) (alreadyRes
 // GetAuthenticatedUserLogin fetches the login name of the user authenticated by the token.
 // If the token is empty, returns an error.
 func GetAuthenticatedUserLogin(ctx context.Context, token string) (string, error) {
+	diag, err := GetTokenDiagnostics(ctx, token)
+	if err != nil {
+		return "", err
+	}
+	return diag.Login, nil
+}
+
+// TokenDiagnostics holds identity and scope information for a GitHub token,
+// resolved from GET /user. It never carries the token's raw value.
+type TokenDiagnostics struct {
+	// Login is the authenticated user's GitHub login.
+	Login string
+	// Scopes is the OAuth scope list granted to the token, parsed from the
+	// X-OAuth-Scopes response header. Empty for fine-grained PATs and GitHub
+	// App installation tokens, which do not set this header.
+	Scopes []string
+}
+
+// GetTokenDiagnostics fetches the authenticated user's login and the token's
+// OAuth scopes (from the X-OAuth-Scopes response header on GET /user).
+// Intended to diagnose PERMISSION_DENIED failures where read operations
+// succeed but a write operation is rejected because the token's scope does
+// not cover it (review-raven#89). The raw token value is never returned.
+func GetTokenDiagnostics(ctx context.Context, token string) (TokenDiagnostics, error) {
 	if token == "" {
-		return "", errors.New("token must not be empty")
+		return TokenDiagnostics{}, errors.New("token must not be empty")
 	}
 	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	httpClient := oauth2.NewClient(ctx, src)
 	client, err := github.NewClient(github.WithHTTPClient(httpClient))
 	if err != nil {
-		return "", fmt.Errorf("github.NewClient: %w", err)
+		return TokenDiagnostics{}, fmt.Errorf("github.NewClient: %w", err)
 	}
-	user, _, err := client.Users.Get(ctx, "")
+	return getTokenDiagnostics(ctx, client)
+}
+
+func getTokenDiagnostics(ctx context.Context, client *github.Client) (TokenDiagnostics, error) {
+	user, resp, err := client.Users.Get(ctx, "")
 	if err != nil {
-		return "", err
+		return TokenDiagnostics{}, err
 	}
 	login := user.GetLogin()
 	if login == "" {
-		return "", errors.New("empty login returned from GitHub API")
+		return TokenDiagnostics{}, errors.New("empty login returned from GitHub API")
 	}
-	return login, nil
+	var scopes []string
+	if resp != nil && resp.Response != nil {
+		if raw := resp.Response.Header.Get("X-OAuth-Scopes"); raw != "" {
+			for _, s := range strings.Split(raw, ",") {
+				if s = strings.TrimSpace(s); s != "" {
+					scopes = append(scopes, s)
+				}
+			}
+		}
+	}
+	return TokenDiagnostics{Login: login, Scopes: scopes}, nil
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -661,6 +661,71 @@ func TestGetCIStatus(t *testing.T) {
 	})
 }
 
+func TestGetTokenDiagnostics(t *testing.T) {
+	tests := []struct {
+		name       string
+		scopesHdr  string
+		wantScopes []string
+	}{
+		{
+			name:       "X-OAuth-Scopes header present",
+			scopesHdr:  "repo, user",
+			wantScopes: []string{"repo", "user"},
+		},
+		{
+			name:       "X-OAuth-Scopes header absent (fine-grained PAT / GitHub App token)",
+			scopesHdr:  "",
+			wantScopes: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/user", func(w http.ResponseWriter, _ *http.Request) {
+				if tt.scopesHdr != "" {
+					w.Header().Set("X-OAuth-Scopes", tt.scopesHdr)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"login":"octocat"}`)
+			})
+			c, teardown := newTestGHClient(mux)
+			defer teardown()
+
+			diag, err := getTokenDiagnostics(context.Background(), c.gh)
+			if err != nil {
+				t.Fatalf("getTokenDiagnostics() error = %v", err)
+			}
+			if diag.Login != "octocat" {
+				t.Errorf("Login = %q, want %q", diag.Login, "octocat")
+			}
+			if join(diag.Scopes, ",") != join(tt.wantScopes, ",") {
+				t.Errorf("Scopes = %v, want %v", diag.Scopes, tt.wantScopes)
+			}
+		})
+	}
+
+	t.Run("empty login returns error", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/user", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"login":""}`)
+		})
+		c, teardown := newTestGHClient(mux)
+		defer teardown()
+
+		if _, err := getTokenDiagnostics(context.Background(), c.gh); err == nil {
+			t.Fatal("getTokenDiagnostics() error = nil, want error for empty login")
+		}
+	})
+
+	t.Run("empty token returns error", func(t *testing.T) {
+		if _, err := GetTokenDiagnostics(context.Background(), ""); err == nil {
+			t.Fatal("GetTokenDiagnostics() error = nil, want error for empty token")
+		}
+	})
+}
+
 // join concatenates strings with a separator (avoids importing strings in test file).
 func join(ss []string, sep string) string {
 	if len(ss) == 0 {

--- a/internal/tools/diagnostics.go
+++ b/internal/tools/diagnostics.go
@@ -1,0 +1,52 @@
+package tools
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/scottlz0310/review-raven/internal/autherr"
+	ghclient "github.com/scottlz0310/review-raven/internal/github"
+)
+
+// DiagnoseTokenInput is the (empty) input schema for diagnose_github_token.
+type DiagnoseTokenInput struct{}
+
+// DiagnoseTokenOutput is the output schema for diagnose_github_token.
+type DiagnoseTokenOutput struct {
+	Login  string   `json:"login"`
+	Scopes []string `json:"scopes"`
+}
+
+var diagnoseTokenTool = &mcp.Tool{
+	Name: "diagnose_github_token",
+	Description: "現在のリクエストで使われている GitHub トークンの login と OAuth スコープ" +
+		"(GET /user の X-OAuth-Scopes レスポンスヘッダー由来)を返す。" +
+		"read 系ツールは成功するのに write 系ツールが PERMISSION_DENIED になる場合の原因切り分けに使う。" +
+		"fine-grained PAT や GitHub App トークンではヘッダーが存在せず scopes が空配列になることがある。" +
+		"トークン生値は返さない。",
+}
+
+func diagnoseTokenHandler() func(context.Context, *mcp.CallToolRequest, DiagnoseTokenInput) (*mcp.CallToolResult, DiagnoseTokenOutput, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, _ DiagnoseTokenInput) (*mcp.CallToolResult, DiagnoseTokenOutput, error) {
+		token := tokenFromToolRequest(ctx, req)
+		if token == "" {
+			return authErrResult(autherr.NewAuthRequired()), DiagnoseTokenOutput{}, nil
+		}
+
+		diag, err := ghclient.GetTokenDiagnostics(ctx, token)
+		if err != nil {
+			if result, ok := tryAuthResult(err); ok {
+				return result, DiagnoseTokenOutput{}, nil
+			}
+			return nil, DiagnoseTokenOutput{}, err
+		}
+
+		return nil, DiagnoseTokenOutput{Login: diag.Login, Scopes: diag.Scopes}, nil
+	}
+}
+
+// RegisterDiagnoseTokenTool adds diagnose_github_token to the MCP server.
+func RegisterDiagnoseTokenTool(server *mcp.Server) {
+	mcp.AddTool(server, diagnoseTokenTool, diagnoseTokenHandler())
+}

--- a/internal/tools/diagnostics.go
+++ b/internal/tools/diagnostics.go
@@ -27,22 +27,31 @@ var diagnoseTokenTool = &mcp.Tool{
 		"トークン生値は返さない。",
 }
 
+// emptyDiagnoseTokenOutput is returned alongside error results. Scopes is an
+// explicit empty slice (not nil) so JSON marshaling produces [] rather than
+// null, matching the tool description's documented output shape.
+var emptyDiagnoseTokenOutput = DiagnoseTokenOutput{Scopes: []string{}}
+
 func diagnoseTokenHandler() func(context.Context, *mcp.CallToolRequest, DiagnoseTokenInput) (*mcp.CallToolResult, DiagnoseTokenOutput, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, _ DiagnoseTokenInput) (*mcp.CallToolResult, DiagnoseTokenOutput, error) {
 		token := tokenFromToolRequest(ctx, req)
 		if token == "" {
-			return authErrResult(autherr.NewAuthRequired()), DiagnoseTokenOutput{}, nil
+			return authErrResult(autherr.NewAuthRequired()), emptyDiagnoseTokenOutput, nil
 		}
 
 		diag, err := ghclient.GetTokenDiagnostics(ctx, token)
 		if err != nil {
 			if result, ok := tryAuthResult(err); ok {
-				return result, DiagnoseTokenOutput{}, nil
+				return result, emptyDiagnoseTokenOutput, nil
 			}
-			return nil, DiagnoseTokenOutput{}, err
+			return nil, emptyDiagnoseTokenOutput, err
 		}
 
-		return nil, DiagnoseTokenOutput{Login: diag.Login, Scopes: diag.Scopes}, nil
+		scopes := diag.Scopes
+		if scopes == nil {
+			scopes = []string{}
+		}
+		return nil, DiagnoseTokenOutput{Login: diag.Login, Scopes: scopes}, nil
 	}
 }
 

--- a/internal/tools/diagnostics_test.go
+++ b/internal/tools/diagnostics_test.go
@@ -2,7 +2,10 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/scottlz0310/review-raven/internal/autherr"
 )
@@ -10,6 +13,59 @@ import (
 func TestDiagnoseTokenHandlerAuthRequired(t *testing.T) {
 	handler := diagnoseTokenHandler()
 	// nil request → no token in context → AUTH_REQUIRED
-	result, _, err := handler(context.Background(), nil, DiagnoseTokenInput{})
+	result, out, err := handler(context.Background(), nil, DiagnoseTokenInput{})
 	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+	if out.Scopes == nil {
+		t.Error("out.Scopes = nil, want non-nil empty slice (marshals to [] not null)")
+	}
+}
+
+// TestDiagnoseTokenToolMCPRoundTripAuthRequired exercises the tool through the
+// real MCP server/client wire path (not just the raw handler), so output
+// schema validation in toolForErr (go-sdk) actually runs. This guards against
+// regressions where a nil Scopes slice could cause schema validation to
+// replace the structured AUTH_REQUIRED error with a generic
+// "validating tool output" error (review-raven#90 review discussion).
+func TestDiagnoseTokenToolMCPRoundTripAuthRequired(t *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	RegisterDiagnoseTokenTool(srv)
+
+	ct, st := mcp.NewInMemoryTransports()
+	ss, err := srv.Connect(context.Background(), st, nil)
+	if err != nil {
+		t.Fatalf("srv.Connect() error = %v", err)
+	}
+	defer func() { _ = ss.Wait() }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	cs, err := client.Connect(context.Background(), ct, nil)
+	if err != nil {
+		t.Fatalf("client.Connect() error = %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "diagnose_github_token",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool() returned protocol error (want structured AUTH_REQUIRED result): %v", err)
+	}
+	if !res.IsError {
+		t.Error("res.IsError = false, want true")
+	}
+	if len(res.Content) == 0 {
+		t.Fatal("res.Content is empty")
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("res.Content[0] is %T, want *mcp.TextContent", res.Content[0])
+	}
+	var ae autherr.AuthError
+	if err := json.Unmarshal([]byte(tc.Text), &ae); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v, text = %s", err, tc.Text)
+	}
+	if ae.ErrorType != autherr.AUTH_REQUIRED {
+		t.Errorf("ErrorType = %q, want %q", ae.ErrorType, autherr.AUTH_REQUIRED)
+	}
 }

--- a/internal/tools/diagnostics_test.go
+++ b/internal/tools/diagnostics_test.go
@@ -1,0 +1,15 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scottlz0310/review-raven/internal/autherr"
+)
+
+func TestDiagnoseTokenHandlerAuthRequired(t *testing.T) {
+	handler := diagnoseTokenHandler()
+	// nil request → no token in context → AUTH_REQUIRED
+	result, _, err := handler(context.Background(), nil, DiagnoseTokenInput{})
+	assertAuthResult(t, result, err, autherr.AUTH_REQUIRED)
+}

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -276,6 +276,7 @@ func BuildStreamableHandlerWithOptions(db *store.DB, threshold time.Duration, op
 	RegisterRequestTool(srv, clientProvider, db)
 	RegisterThreadTools(srv, clientProvider)
 	RegisterCycleTool(srv, clientProvider, db)
+	RegisterDiagnoseTokenTool(srv)
 
 	sessionTimeout := resolveStreamableSessionTimeout(os.Getenv)
 	if sessionTimeout == 0 {


### PR DESCRIPTION
## Summary

- `reply_and_resolve_review_thread` 等の write 操作が `PERMISSION_DENIED` (403) になる一方で read 操作は成功するケースの原因切り分け用に、新規 MCP ツール `diagnose_github_token` を追加
- 現在のリクエストで使われているトークン(既存ツールと同じ取得経路)で `GET /user` を呼び、`login` と `X-OAuth-Scopes` レスポンスヘッダー由来の `scopes` を返す。トークン生値はレスポンス・ログのいずれにも含めない
- `internal/github/client.go`: 既存の `GetAuthenticatedUserLogin` が呼んでいたロジックを一般化した `GetTokenDiagnostics` を追加。`GetAuthenticatedUserLogin` はこれを利用する形にリファクタ(挙動は変更なし)

## 背景

#89 の切り分け手順「①review-raven が受け取ったトークンで `GET /user` を呼び `X-OAuth-Scopes` を確認する診断手段を用意する」に対応。他の切り分け項目(稼働環境の `OAUTH_SCOPES` 設定確認、mcp-gateway `/internal/v1/whoami` の委任トークン種別確認、再認証フローで承認したスコープ確認)は review-raven 外の運用調査のため対象外。マージ後、稼働環境のコンテナを再作成し、本ツールで実際に原因を切り分ける想定。#89 は原因判明まで OPEN で維持する。

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`(全パッケージ green)
- [x] `internal/github/client_test.go` に `TestGetTokenDiagnostics` を追加(X-OAuth-Scopes 有無、空 login、空トークンのケース)
- [x] `internal/tools/diagnostics_test.go` に `diagnose_github_token` の AUTH_REQUIRED ケースを追加
- [ ] レビューサイクル完了後、マージしてコンテナ再作成 → 実運用での動作確認(別途対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)