### PR TITLE
fix: GraphQL の Resource not accessible by integration を PERMISSION_DENIED に分類

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -19,6 +19,10 @@
 
 - `docs/skills/thread-owl-review-cycle.md` / `.ja.md` — thread-owl reviewed-side cycle 用の新 skill を追加。ページネーション付き GraphQL でレビュースレッドを取得し、分類・修正・返信・resolve を行い、再レビューが必要な場合は `@thread-owl re-review requested` コメントを投稿して cycle を完了する。次の reviewer-side cycle は thread-owl webhook が起動する。([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
 
+### 修正
+
+- `ClassifyGitHubError` が GitHub GraphQL の `"Resource not accessible by integration"` メッセージ(GitHub App installation token に必要なリポジトリ権限がない場合、HTTP 200 とともに返される)を認識し、生の Go エラー文字列を MCP tool 呼び出し元に漏らす代わりに `PERMISSION_DENIED` として分類するようにしました。[Issue #89](https://github.com/scottlz0310/review-raven/issues/89) の調査中に発見。([Issue #92](https://github.com/scottlz0310/review-raven/issues/92))
+
 ### 変更
 
 - `docs/skills/thread-owl-review-cycle.ja.md` / `.md` — PR HEAD 同期ゲートを追加し、未 push の状態で返信・resolve・再レビュー依頼へ進むのを防止するようにしました。また、再レビュー依頼のアノテーションやサマリコメントに `expected_head` を記録するようにし、Phase 8 のマージ条件に PR HEAD SHA の照合ゲート（不一致時は `APPROVED_HEAD_MISMATCH` として停止）を追加しました。([Issue #84](https://github.com/scottlz0310/review-raven/issues/84))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `docs/skills/thread-owl-review-cycle.md` / `.ja.md` — new skill for the thread-owl reviewed-side cycle. Reads review threads via paginated GraphQL, classifies and fixes, replies and resolves, then posts `@thread-owl re-review requested` as the re-review path. The reviewed-side cycle ends there; the next reviewer-side cycle is triggered by thread-owl's webhook. ([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
 
+### Fixed
+
+- `ClassifyGitHubError` now recognizes GitHub GraphQL's `"Resource not accessible by integration"` message (returned with HTTP 200 when a GitHub App installation token lacks the required repository permission) and classifies it as `PERMISSION_DENIED`, instead of leaking the raw Go error string to MCP tool callers. Found while investigating [Issue #89](https://github.com/scottlz0310/review-raven/issues/89). ([Issue #92](https://github.com/scottlz0310/review-raven/issues/92))
+
 ### Changed
 
 - `docs/skills/thread-owl-review-cycle.ja.md` / `.md` — Added a PR HEAD sync gate to prevent proceeding with reply, resolve, and re-review request before local fixes are pushed. Added `expected_head` tracking to re-review request comment annotations and summary comments. Added PR HEAD SHA verification gate to Phase 8 merge conditions (blocks merge with `APPROVED_HEAD_MISMATCH` on mismatch). ([Issue #84](https://github.com/scottlz0310/review-raven/issues/84))

--- a/internal/github/classify.go
+++ b/internal/github/classify.go
@@ -113,7 +113,11 @@ func ClassifyGitHubError(err error) *autherr.AuthError {
 	switch {
 	case strings.Contains(msg, "401 Unauthorized"):
 		return autherr.NewReauthRequired()
-	case strings.Contains(msg, "403 Forbidden"):
+	case strings.Contains(msg, "403 Forbidden"),
+		strings.Contains(msg, "Resource not accessible by integration"):
+		// GitHub GraphQL API returns HTTP 200 with this message (not "403
+		// Forbidden") when a GitHub App installation token lacks the
+		// required repository permission (review-raven#92).
 		return autherr.NewPermissionDenied()
 	case strings.Contains(msg, "404 Not Found"):
 		return autherr.NewNotFound()

--- a/internal/github/classify_test.go
+++ b/internal/github/classify_test.go
@@ -133,6 +133,8 @@ func TestClassifyGitHubError_GraphQLStrings(t *testing.T) {
 		{"non-200 OK status code: 502 Bad Gateway body: upstream", autherr.TRANSIENT_UPSTREAM_ERROR},
 		{"non-200 OK status code: 503 Service Unavailable body: down", autherr.TRANSIENT_UPSTREAM_ERROR},
 		{"non-200 OK status code: 504 Gateway Timeout body: slow", autherr.TRANSIENT_UPSTREAM_ERROR},
+		{"Resource not accessible by integration", autherr.PERMISSION_DENIED},
+		{"graphql mutation failed: Resource not accessible by integration", autherr.PERMISSION_DENIED},
 	}
 	for _, tc := range cases {
 		t.Run(tc.msg[:30], func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `ClassifyGitHubError`(`internal/github/classify.go`)の文字列ベースフォールバックに `"Resource not accessible by integration"` パターンを追加し、`PERMISSION_DENIED` に分類するようにした
- GitHub GraphQL API は GitHub App installation token に必要な repository permission が無い場合、HTTP 200 とともにこのメッセージを返すため、既存の `"403 Forbidden"` 文字列マッチには引っかからず未分類の生エラーが MCP tool 呼び出し元に漏れていた

## 背景

Closes #92

#89 の調査中(使い捨てPR #91)、`resolve_review_thread`(GraphQL mutation 経由)を呼んだ際に構造化 `PERMISSION_DENIED` ではなく生の `graphql mutation failed: Resource not accessible by integration` が返ることを発見した。同じ権限不足が原因の `reply_to_review_thread`(REST API 経由)は正しく分類されていたため、GraphQL 経路特有の分類漏れと判明。

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`(全パッケージ green)
- [x] `classify_test.go` に `"Resource not accessible by integration"` 単体および `"graphql mutation failed: ..."` ラップ済みの2ケースを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)