### PR TITLE
chore(deps): migrate go-github v88 → v89

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/scottlz0310/review-raven
 go 1.26.5
 
 require (
-	github.com/google/go-github/v88 v88.0.0
 	github.com/google/go-github/v89 v89.0.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,7 @@ github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArs
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
-github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
+github.com/google/go-github/v89 v89.0.0 h1:35bEK5XoEcF3PZrlVbl9XN63f5BcJRA/UGkxeC9xPg0=
 github.com/google/go-github/v89 v89.0.0/go.mod h1:QLcbU0ipeAqQuR5KSg8c2lql4Qk1EwJ2dWz/0rP4Nho=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=

--- a/internal/github/auth_error_test.go
+++ b/internal/github/auth_error_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 )
 
 func TestIsAuthError(t *testing.T) {

--- a/internal/github/classify.go
+++ b/internal/github/classify.go
@@ -28,6 +28,25 @@ func HTTPStatusError(statusCode int) error {
 	return &github.ErrorResponse{Response: &http.Response{StatusCode: statusCode}}
 }
 
+// NewRateLimitError returns a primary rate-limit error (HTTP 403 + X-RateLimit-Remaining: 0).
+// Intended for tests that need to trigger RATE_LIMITED without importing go-github directly.
+func NewRateLimitError() error {
+	return &github.RateLimitError{
+		Rate:     github.Rate{},
+		Response: &http.Response{StatusCode: http.StatusForbidden},
+		Message:  "API rate limit exceeded",
+	}
+}
+
+// NewAbuseRateLimitError returns a secondary/abuse rate-limit error (HTTP 403 + abuse message).
+// Intended for tests that need to trigger secondary RATE_LIMITED without importing go-github directly.
+func NewAbuseRateLimitError() error {
+	return &github.AbuseRateLimitError{
+		Response: &http.Response{StatusCode: http.StatusForbidden},
+		Message:  "You have exceeded a secondary rate limit",
+	}
+}
+
 // ClassifyGitHubError maps a GitHub API or gateway error to a structured *autherr.AuthError.
 // Returns nil when the error is not a recognized error type (e.g. context.Canceled).
 //

--- a/internal/github/classify.go
+++ b/internal/github/classify.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 
 	"github.com/scottlz0310/review-raven/internal/autherr"
 )

--- a/internal/github/classify_test.go
+++ b/internal/github/classify_test.go
@@ -186,6 +186,46 @@ func TestClassifyGitHubError_UnknownError(t *testing.T) {
 	}
 }
 
+func TestNewRateLimitError(t *testing.T) {
+	err := ghclient.NewRateLimitError()
+	if err == nil {
+		t.Fatal("NewRateLimitError() = nil")
+	}
+	got := ghclient.ClassifyGitHubError(err)
+	if got == nil {
+		t.Fatal("ClassifyGitHubError(NewRateLimitError()) = nil, want RATE_LIMITED")
+	}
+	if got.ErrorType != autherr.RATE_LIMITED {
+		t.Errorf("ErrorType = %q, want %q", got.ErrorType, autherr.RATE_LIMITED)
+	}
+	if !got.Retryable {
+		t.Error("Retryable = false, want true for primary rate limit")
+	}
+	if !ghclient.IsRateLimitHTTPError(err) {
+		t.Error("IsRateLimitHTTPError = false, want true")
+	}
+}
+
+func TestNewAbuseRateLimitError(t *testing.T) {
+	err := ghclient.NewAbuseRateLimitError()
+	if err == nil {
+		t.Fatal("NewAbuseRateLimitError() = nil")
+	}
+	got := ghclient.ClassifyGitHubError(err)
+	if got == nil {
+		t.Fatal("ClassifyGitHubError(NewAbuseRateLimitError()) = nil, want RATE_LIMITED")
+	}
+	if got.ErrorType != autherr.RATE_LIMITED {
+		t.Errorf("ErrorType = %q, want %q", got.ErrorType, autherr.RATE_LIMITED)
+	}
+	if got.Retryable {
+		t.Error("Retryable = true, want false for secondary rate limit")
+	}
+	if !ghclient.IsRateLimitHTTPError(err) {
+		t.Error("IsRateLimitHTTPError = false, want true")
+	}
+}
+
 func TestIsRateLimitHTTPError(t *testing.T) {
 	t.Run("matches typed rate limit errors", func(t *testing.T) {
 		if !ghclient.IsRateLimitHTTPError(&github.RateLimitError{Rate: github.Rate{Remaining: 0}}) {

--- a/internal/github/classify_test.go
+++ b/internal/github/classify_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 
 	"github.com/scottlz0310/review-raven/internal/autherr"
 	ghclient "github.com/scottlz0310/review-raven/internal/github"

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -181,6 +181,19 @@ func NewWithHTTPClientAndURL(httpClient *http.Client, baseURL string, threshold 
 	return &Client{gh: gh, threshold: threshold}, nil
 }
 
+// NewWithHTTPClientAndURLFull creates a Client with both REST and GraphQL clients
+// pointing at baseURL, using httpClient for all requests. Intended for tests that
+// need to route both REST and GraphQL calls to an httptest server without importing
+// go-github or githubv4 directly.
+func NewWithHTTPClientAndURLFull(httpClient *http.Client, baseURL string, threshold time.Duration) (*Client, error) {
+	restBase := baseURL + "/"
+	gh, err := github.NewClient(github.WithHTTPClient(httpClient), github.WithURLs(&restBase, &restBase))
+	if err != nil {
+		return nil, fmt.Errorf("github.NewClient: %w", err)
+	}
+	return &Client{gh: gh, v4: githubv4.NewEnterpriseClient(baseURL, httpClient), threshold: threshold}, nil
+}
+
 // GetReviewData fetches raw reviewer and review data for a PR from GitHub.
 func (c *Client) GetReviewData(ctx context.Context, owner, repo string, prNumber int) (*ReviewData, error) {
 	data := &ReviewData{}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -904,6 +904,13 @@ func TestNewWithHTTPClientAndURLFull(t *testing.T) {
 	}
 }
 
+func TestNewWithHTTPClientAndURLFullInvalidURL(t *testing.T) {
+	_, err := NewWithHTTPClientAndURLFull(http.DefaultClient, "://invalid-url", 30*time.Second)
+	if err == nil {
+		t.Fatal("NewWithHTTPClientAndURLFull() expected error for invalid URL, got nil")
+	}
+}
+
 func TestIsCopilotLoginCoversAllKnownIdentities(t *testing.T) {
 	cases := []struct {
 		login string

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/shurcooL/githubv4"
 )
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -872,6 +872,38 @@ func TestGetReviewDataTimelinePicksLatestEvents(t *testing.T) {
 
 // TestIsCopilotLoginCoversAllKnownIdentities verifies that all known Copilot
 // reviewer identities are recognized, including the REST requested_reviewers form.
+func TestNewWithHTTPClientAndURLFull(t *testing.T) {
+	var restHit, gqlHit atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			// GraphQL request
+			gqlHit.Store(true)
+			_, _ = fmt.Fprint(w, `{"data":{}}`)
+		} else {
+			// REST request
+			restHit.Store(true)
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprint(w, `{"message":"Not Found"}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := NewWithHTTPClientAndURLFull(srv.Client(), srv.URL, 30*time.Second)
+	if err != nil {
+		t.Fatalf("NewWithHTTPClientAndURLFull() error = %v", err)
+	}
+	if c == nil {
+		t.Fatal("NewWithHTTPClientAndURLFull() = nil")
+	}
+	if c.gh == nil {
+		t.Error("REST client (gh) is nil")
+	}
+	if c.v4 == nil {
+		t.Error("GraphQL client (v4) is nil")
+	}
+}
+
 func TestIsCopilotLoginCoversAllKnownIdentities(t *testing.T) {
 	cases := []struct {
 		login string

--- a/internal/tools/auth_error_test.go
+++ b/internal/tools/auth_error_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/shurcooL/githubv4"
 

--- a/internal/tools/auth_error_test.go
+++ b/internal/tools/auth_error_test.go
@@ -12,9 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v89/github"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/shurcooL/githubv4"
 
 	"github.com/scottlz0310/review-raven/internal/autherr"
 	ghclient "github.com/scottlz0310/review-raven/internal/github"
@@ -40,13 +38,11 @@ func new401Server() *httptest.Server {
 
 // make401GitHubClient creates a *ghclient.Client pointing at a server that returns 401.
 func make401GitHubClient(srv *httptest.Server) *ghclient.Client {
-	srvURL := srv.URL + "/"
-	restClient, err := github.NewClient(github.WithHTTPClient(srv.Client()), github.WithURLs(&srvURL, &srvURL))
+	c, err := ghclient.NewWithHTTPClientAndURLFull(srv.Client(), srv.URL, 30*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("make401GitHubClient: %v", err))
 	}
-	gqlClient := githubv4.NewEnterpriseClient(srv.URL, srv.Client())
-	return ghclient.NewWithClients(restClient, gqlClient, 30*time.Second)
+	return c
 }
 
 // decodeAuthError unmarshals the text content of a *mcp.CallToolResult into *autherr.AuthError.
@@ -336,13 +332,11 @@ func newStatusServer(status int) *httptest.Server {
 
 // makeStatusGitHubClient creates a *ghclient.Client pointing at the given server.
 func makeStatusGitHubClient(srv *httptest.Server) *ghclient.Client {
-	srvURL := srv.URL + "/"
-	restClient, err := github.NewClient(github.WithHTTPClient(srv.Client()), github.WithURLs(&srvURL, &srvURL))
+	c, err := ghclient.NewWithHTTPClientAndURLFull(srv.Client(), srv.URL, 30*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("makeStatusGitHubClient: %v", err))
 	}
-	gqlClient := githubv4.NewEnterpriseClient(srv.URL, srv.Client())
-	return ghclient.NewWithClients(restClient, gqlClient, 30*time.Second)
+	return c
 }
 
 // assertBlockingResult checks result is a non-nil error result with the given error type.
@@ -454,20 +448,13 @@ func TestTryAuthResultNewErrorTypes(t *testing.T) {
 		{"TRANSIENT_UPSTREAM_ERROR", autherr.NewTransientUpstreamError(), autherr.TRANSIENT_UPSTREAM_ERROR, true},
 		{
 			"RATE_LIMITED_primary (via RateLimitError)",
-			&github.RateLimitError{
-				Rate:     github.Rate{},
-				Response: &http.Response{StatusCode: http.StatusForbidden},
-				Message:  "rate limit exceeded",
-			},
+			ghclient.NewRateLimitError(),
 			autherr.RATE_LIMITED,
 			true,
 		},
 		{
 			"RATE_LIMITED_secondary (via AbuseRateLimitError)",
-			&github.AbuseRateLimitError{
-				Response: &http.Response{StatusCode: http.StatusForbidden},
-				Message:  "secondary rate limit",
-			},
+			ghclient.NewAbuseRateLimitError(),
 			autherr.RATE_LIMITED,
 			false,
 		},

--- a/internal/tools/request_test.go
+++ b/internal/tools/request_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v88/github"
+	"github.com/google/go-github/v89/github"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/shurcooL/githubv4"
 

--- a/internal/tools/request_test.go
+++ b/internal/tools/request_test.go
@@ -11,9 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v89/github"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/shurcooL/githubv4"
 
 	ghclient "github.com/scottlz0310/review-raven/internal/github"
 	"github.com/scottlz0310/review-raven/internal/store"
@@ -52,13 +50,11 @@ func newGitHubAPIMock(t *testing.T, submittedAt time.Time) *httptest.Server {
 
 // makeGitHubClient creates a *ghclient.Client that routes all API calls to srv.
 func makeGitHubClient(srv *httptest.Server) *ghclient.Client {
-	srvURL := srv.URL + "/"
-	restClient, err := github.NewClient(github.WithHTTPClient(srv.Client()), github.WithURLs(&srvURL, &srvURL))
+	c, err := ghclient.NewWithHTTPClientAndURLFull(srv.Client(), srv.URL, 30*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("makeGitHubClient: %v", err))
 	}
-	gqlClient := githubv4.NewEnterpriseClient(srv.URL, srv.Client())
-	return ghclient.NewWithClients(restClient, gqlClient, 30*time.Second)
+	return c
 }
 
 // staticProvider returns a githubClientProvider that always returns the given client.


### PR DESCRIPTION
## Summary

- Update all `github.com/google/go-github/v88` import paths to `v89` across 7 source files
- Remove the orphan `v88` require entry from `go.mod`; run `go mod tidy` to refresh `go.sum`
- Centralize go-github / githubv4 test helpers into `internal/github/` so future Renovate major-version bumps only require changes in that one directory
- Add tests covering the new helper functions (100% patch coverage)

No API changes were required — the `PullRequests`, `Issues`, `Checks`, and `Users` methods used by review-raven are identical between v88 and v89.

## Files changed

### Dependency migration (commit `e958286`)

| File | Change |
|------|--------|
| `go.mod` | Remove `v88` require; keep only `v89` |
| `go.sum` | Updated by `go mod tidy` |
| `internal/github/classify.go` | Import path `v88` → `v89` |
| `internal/github/client.go` | Import path `v88` → `v89` |
| `internal/github/classify_test.go` | Import path `v88` → `v89` |
| `internal/github/client_test.go` | Import path `v88` → `v89` |
| `internal/github/auth_error_test.go` | Import path `v88` → `v89` |
| `internal/tools/request_test.go` | Import path `v88` → `v89` |
| `internal/tools/auth_error_test.go` | Import path `v88` → `v89` |

### go-github import centralization (commits `b52b1b0`–`aa7b8dc`)

Added to `internal/github/` so tests outside that package no longer import go-github or githubv4 directly:

| Symbol | File | Purpose |
|--------|------|---------|
| `NewWithHTTPClientAndURLFull` | `client.go` | Creates a `*Client` with both REST and GraphQL clients from an `*http.Client` + base URL — replaces inline `github.NewClient` + `githubv4.NewEnterpriseClient` calls in test helpers |
| `NewRateLimitError` | `classify.go` | Returns a `*github.RateLimitError` (primary rate limit, retryable) without callers importing go-github |
| `NewAbuseRateLimitError` | `classify.go` | Returns a `*github.AbuseRateLimitError` (secondary rate limit, non-retryable) without callers importing go-github |

Removed direct go-github and githubv4 imports from:
- `internal/tools/auth_error_test.go`
- `internal/tools/request_test.go`

Added regression tests in `internal/github/` for all three new helpers (including the error path of `NewWithHTTPClientAndURLFull`).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all 6 packages pass
- [x] Codecov — all modified lines covered

Closes / supersedes Renovate PR #104.