### PR TITLE
refactor(auth): GPAT fallbackを削除してgateway認証を必須化

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -15,8 +15,6 @@
 
 - `spike-request-scoped-reauth.md` / `.ja.md` — `get_review_threads` 等のリクエストスコープ（非 watch）tool call で `REAUTH_REQUIRED` が頻発する問題の spike 調査結果。根本原因は mcp-gateway builtin mode が token 交換時に GitHub provider アクセストークンを破棄するため、`EnsureFreshAccessTokenForSubject` が gateway RS256 JWT を Bearer として review-raven に渡し、GitHub が毎回 401 を返すこと。修正は mcp-gateway 側に帰属（[mcp-gateway#188](https://github.com/scottlz0310/mcp-gateway/issues/188) として起票済み）。review-raven 側のコード修正は不要。([Issue #87](https://github.com/scottlz0310/review-raven/issues/87))
 
-- `auth=none` ルート向けのデフォルト認証情報とデフォルトユーザー名の動的解決フォールバックを追加: `X-Authenticated-User` および `Authorization` ヘッダーが欠落している場合（`auth=none` プロキシルートなど）に、デフォルト値へフォールバックできるようにしました。`REVIEW_RAVEN_DEFAULT_USER` が明示的に設定されていない場合は、`GITHUB_PERSONAL_ACCESS_TOKEN` を使って GitHub API の `GET /user` を呼び出すことで、トークンの所有者のログイン名を動的に解決してフォールバック値とします。([Issue #80](https://github.com/scottlz0310/review-raven/issues/80))
-
 - `docs/skills/thread-owl-review-cycle.md` / `.ja.md` — thread-owl reviewed-side cycle 用の新 skill を追加。ページネーション付き GraphQL でレビュースレッドを取得し、分類・修正・返信・resolve を行い、再レビューが必要な場合は `@thread-owl re-review requested` コメントを投稿して cycle を完了する。次の reviewer-side cycle は thread-owl webhook が起動する。([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
 
 ### 修正
@@ -36,6 +34,8 @@
 - `docs/architecture.md` / `.ja.md` — 再レビュー依頼フローのセクションを追加。review-raven（コメント投稿）・thread-owl（webhook → queue）・mcp-resource-subscriber（購読ブリッジ）の責務境界を文書化。([Issue #69](https://github.com/scottlz0310/review-raven/issues/69))
 
 ### 削除
+
+- process-wide な `GITHUB_PERSONAL_ACCESS_TOKEN` / `REVIEW_RAVEN_DEFAULT_USER` fallback を削除。すべての GitHub API 経路で mcp-gateway が request ごとに注入する identity と Bearer token を必須とし、ヘッダー欠落・不正時は fail-closed で拒否する。([Issue #106](https://github.com/scottlz0310/review-raven/issues/106))
 
 - **旧 `copilot-review://` URI スキームおよび `COPILOT_REVIEW_*` 環境変数を削除** ([Issue #66](https://github.com/scottlz0310/review-raven/issues/66)):
   - `SubscribeHandler` が `copilot-review://watch/...` URI に対して `ResourceNotFoundError` を返すよう修正。従来は `nil` を返すためゴースト購読が成立していた。アクティブな watch は再依頼が必要。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `spike-request-scoped-reauth.md` / `.ja.md` — spike investigation into frequent `REAUTH_REQUIRED` on request-scoped (non-watch) tool calls such as `get_review_threads`. Root cause: mcp-gateway builtin mode discards the GitHub provider access token at token exchange, so `EnsureFreshAccessTokenForSubject` hands the gateway RS256 JWT to review-raven as the Bearer token and GitHub rejects it with 401 on every call. Fix belongs to mcp-gateway (filed as [mcp-gateway#188](https://github.com/scottlz0310/mcp-gateway/issues/188)); no review-raven code change required. ([Issue #87](https://github.com/scottlz0310/review-raven/issues/87))
 
-- Default credentials and dynamic default user resolution for `auth=none` routes: When `X-Authenticated-User` and `Authorization` headers are missing (such as in `auth=none` proxy routes), the server can fall back to default values. The default user is dynamically resolved by calling GitHub's `GET /user` endpoint using the `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable if `REVIEW_RAVEN_DEFAULT_USER` is not explicitly set. ([Issue #80](https://github.com/scottlz0310/review-raven/issues/80))
-
 - `docs/skills/thread-owl-review-cycle.md` / `.ja.md` — new skill for the thread-owl reviewed-side cycle. Reads review threads via paginated GraphQL, classifies and fixes, replies and resolves, then posts `@thread-owl re-review requested` as the re-review path. The reviewed-side cycle ends there; the next reviewer-side cycle is triggered by thread-owl's webhook. ([Issue #71](https://github.com/scottlz0310/review-raven/issues/71))
 
 ### Fixed
@@ -36,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/architecture.md` / `.ja.md` — added Re-review request flow section documenting the responsibility boundary between review-raven (posts comment), thread-owl (webhook → queue), and mcp-resource-subscriber (subscription bridge). ([Issue #69](https://github.com/scottlz0310/review-raven/issues/69))
 
 ### Removed
+
+- Removed the process-wide `GITHUB_PERSONAL_ACCESS_TOKEN` / `REVIEW_RAVEN_DEFAULT_USER` fallback. Every GitHub API path now requires the request-scoped identity and Bearer token injected by mcp-gateway and fails closed when either header is missing or malformed. ([Issue #106](https://github.com/scottlz0310/review-raven/issues/106))
 
 - **Legacy `copilot-review://` URI scheme and `COPILOT_REVIEW_*` env vars removed** ([Issue #66](https://github.com/scottlz0310/review-raven/issues/66)):
   - `SubscribeHandler` now returns `ResourceNotFoundError` for `copilot-review://watch/...` URIs instead of silently succeeding (ghost subscriptions). Re-request any active watches.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -38,23 +38,7 @@ func main() {
 
 	slog.Info("auth mode: gateway (trusting X-Authenticated-User header from mcp-gateway)")
 
-	// Resolve default credentials for auth=none fallback (e.g., local development).
-	defaultToken := os.Getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
-	defaultUser := os.Getenv("REVIEW_RAVEN_DEFAULT_USER")
-	if defaultUser == "" && defaultToken != "" {
-		// Try to resolve user login dynamically from GitHub API whoami endpoint.
-		// Use a short timeout so startup is not blocked indefinitely if offline.
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if login, err := ghclient.GetAuthenticatedUserLogin(ctx, defaultToken); err == nil {
-			defaultUser = login
-			slog.Info("resolved default user from GitHub API", "login", login)
-		} else {
-			slog.Warn("failed to resolve default user from token", "err", err)
-		}
-		cancel()
-	}
-
-	authMiddleware := middleware.Auth(defaultUser, defaultToken)
+	authMiddleware := middleware.Auth()
 
 	mux := http.NewServeMux()
 
@@ -170,9 +154,8 @@ func loadConfig() config {
 // Endpoint URL and shared secret are validated at startup in loadConfig, so
 // the only failure remaining at watch creation is an empty GitHub login
 // (which would indicate a session-binding bug, not a config error). In that
-// case we log at Error level and fall back to the static token so the watch
-// can still make progress; this preserves availability but is loud enough
-// for ops to detect that Phase B is not actually engaged.
+// case we log at Error level and keep using the request-scoped token supplied
+// by mcp-gateway. No process-wide credential fallback exists.
 func buildGatewayClientFactory(endpointURL, secret string, threshold time.Duration) func(ctx context.Context, token, login string) watch.ReviewDataFetcher {
 	sharedHTTP := &http.Client{Timeout: ghclient.DefaultGatewayTimeout}
 	return func(ctx context.Context, token, login string) watch.ReviewDataFetcher {
@@ -184,7 +167,7 @@ func buildGatewayClientFactory(endpointURL, secret string, threshold time.Durati
 			Context:     ctx,
 		})
 		if err != nil {
-			slog.Error("gateway token source unavailable; phase B disabled for this watch, falling back to static token",
+			slog.Error("gateway token source unavailable; phase B disabled for this watch, using request-scoped token",
 				"login", login, "err", err)
 			return ghclient.NewClient(ctx, token, threshold, nil)
 		}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -772,16 +772,6 @@ func (c *Client) ResolveThread(ctx context.Context, threadID string) (alreadyRes
 	return false, nil
 }
 
-// GetAuthenticatedUserLogin fetches the login name of the user authenticated by the token.
-// If the token is empty, returns an error.
-func GetAuthenticatedUserLogin(ctx context.Context, token string) (string, error) {
-	diag, err := GetTokenDiagnostics(ctx, token)
-	if err != nil {
-		return "", err
-	}
-	return diag.Login, nil
-}
-
 // TokenDiagnostics holds identity and scope information for a GitHub token,
 // resolved from GET /user. It never carries the token's raw value.
 type TokenDiagnostics struct {

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -12,24 +12,18 @@ type contextKey string
 const ContextKeyLogin contextKey = "github_login"
 const ContextKeyToken contextKey = "github_token"
 
-// Auth returns a middleware that trusts the X-Authenticated-User header and
-// Bearer token injected by an upstream proxy (mcp-gateway). If headers are missing,
-// it falls back to the provided defaultLogin and defaultToken (useful for auth=none).
-func Auth(defaultLogin, defaultToken string) func(http.Handler) http.Handler {
+// Auth returns a middleware that requires the identity and Bearer token
+// injected by mcp-gateway. Missing or malformed headers fail closed; there is
+// no process-wide credential fallback.
+func Auth() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			login := r.Header.Get("X-Authenticated-User")
-			if login == "" {
-				login = defaultLogin
-			}
 			if login == "" {
 				writeUnauthorized(w, "missing_proxy_identity")
 				return
 			}
 			token := extractBearer(r)
-			if token == "" {
-				token = defaultToken
-			}
 			if token == "" {
 				writeUnauthorized(w, "missing_token")
 				return

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -26,6 +26,12 @@ func TestAuth_TrustProxyHeaders(t *testing.T) {
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
+			name:       "basic authorization fails closed",
+			proxyLogin: "bob",
+			authHeader: "Basic abc",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
 			name:           "valid proxy identity with bearer token propagated to context",
 			proxyLogin:     "carol",
 			authHeader:     "Bearer proxy-token",
@@ -37,74 +43,7 @@ func TestAuth_TrustProxyHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mw := Auth("", "")
-
-			var capturedLogin, capturedToken string
-			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				capturedLogin = LoginFromContext(r.Context())
-				capturedToken = TokenFromContext(r.Context())
-				w.WriteHeader(http.StatusOK)
-			})
-
-			req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
-			if tt.proxyLogin != "" {
-				req.Header.Set("X-Authenticated-User", tt.proxyLogin)
-			}
-			if tt.authHeader != "" {
-				req.Header.Set("Authorization", tt.authHeader)
-			}
-			rec := httptest.NewRecorder()
-			mw(next).ServeHTTP(rec, req)
-
-			if rec.Code != tt.wantStatus {
-				t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
-			}
-			if tt.wantLogin != "" && capturedLogin != tt.wantLogin {
-				t.Fatalf("login = %q, want %q", capturedLogin, tt.wantLogin)
-			}
-			if capturedToken != tt.wantTokenInCtx {
-				t.Fatalf("token in context = %q, want %q", capturedToken, tt.wantTokenInCtx)
-			}
-		})
-	}
-}
-
-func TestAuth_Fallback(t *testing.T) {
-	tests := []struct {
-		name           string
-		defaultLogin   string
-		defaultToken   string
-		proxyLogin     string
-		authHeader     string
-		wantStatus     int
-		wantLogin      string
-		wantTokenInCtx string
-	}{
-		{
-			name:           "missing headers falls back to default values",
-			defaultLogin:   "default-user",
-			defaultToken:   "default-token",
-			proxyLogin:     "",
-			authHeader:     "",
-			wantStatus:     http.StatusOK,
-			wantLogin:      "default-user",
-			wantTokenInCtx: "default-token",
-		},
-		{
-			name:           "headers take precedence over default values",
-			defaultLogin:   "default-user",
-			defaultToken:   "default-token",
-			proxyLogin:     "override-user",
-			authHeader:     "Bearer override-token",
-			wantStatus:     http.StatusOK,
-			wantLogin:      "override-user",
-			wantTokenInCtx: "override-token",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mw := Auth(tt.defaultLogin, tt.defaultToken)
+			mw := Auth()
 
 			var capturedLogin, capturedToken string
 			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## 概要

process-wideなGPAT/default-user fallbackを削除し、すべてのGitHub API経路でmcp-gatewayがリクエストごとに注入するidentityとBearer tokenを必須化します。

Closes #106

依存PR:
- scottlz0310/mcp-gateway#213

関連Issue:
- scottlz0310/mcp-gateway#212
- scottlz0310/Mcp-Docker#225

適用順序: mcp-gateway#213 → このPR → Mcp-Docker#225のPR

## 変更内容

- `GITHUB_PERSONAL_ACCESS_TOKEN` fallbackを削除
- `REVIEW_RAVEN_DEFAULT_USER` fallbackと起動時`GET /user`解決を削除
- middlewareで`X-Authenticated-User`とBearer tokenを必須化
- Basic認証やヘッダー欠落をfail-closedで拒否
- 不要になったauthenticated-user解決helperを削除
- CHANGELOGを更新

## 影響

- `auth=none`とprocess-wide資格情報を組み合わせた起動方法は利用できなくなります。
- mcp-gateway経由のrequest-scoped認証が必須です。
- watch作成時のgateway token sourceが利用できない場合も、初期リクエストのtokenだけを使用し、GPATへはfallbackしません。

## 検証

- `go test ./...`
- `go vet ./...`
- `git diff --check`