### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-26
+
+> **破壊的変更を含むリリースです。** `initialize` handshake でセッションを開く client は拒否されます。protocol `2026-07-28` の `server/discover` で discovery してください。
+
 ### 変更
 
 - **破壊的変更: 非推奨の `initialize` handshake を拒否するようにしました。** review-raven は MCP protocol `2026-07-28` のみを提供するため、`initialize` を含む POST には HTTP 400 と JSON-RPC `-32022`（`unsupported protocol version`）を返します。`data` には `supported: ["2026-07-28"]` と client が要求したバージョンを載せます。batch body は全体を 1 つの応答で拒否するため、その応答の `id` は null になります（batch 内のどの request にも帰属しないため）。従来は go-sdk が handshake に応答し、client の legacy revision へネゴシエートしていました — Codex 0.149.1 の A/B 検証（`mcp_2026_07_28` を process-local に無効化）では、thread-owl が既に拒否している `2025-06-18` に対して review-raven だけが `ready` のままであり、SEP-2575 以前の client が到達できる最後の server として残っていました。go-sdk には server 側の切り替えスイッチが無いため、SDK handler の手前で handshake を遮断します。この拒否契約は、TS SDK の `legacy: "reject"` が thread-owl に提供している modern-only 拒否と同じ形です。client は `server/discover` で discovery してください。[thread-owl#165](https://github.com/scottlz0310/thread-owl/issues/165) の repo 横断 MCP `2026-07-28` 移行の一部です。([Issue #117](https://github.com/scottlz0310/review-raven/issues/117))
@@ -174,6 +178,7 @@
 - この独立リポジトリでは、Mcp-Docker 時代の `review-raven` service 作業から release continuity を引き継ぐ。git 履歴は移行していない。
 - 関連する設計・移行経緯は `docs/` 配下を参照。
 
-[Unreleased]: https://github.com/scottlz0310/review-raven/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/review-raven/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/scottlz0310/review-raven/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/scottlz0310/review-raven/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/scottlz0310/review-raven/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-26
+
+> **Breaking release.** Clients that still open a session with the `initialize` handshake are refused. Discover the server through `server/discover` on protocol `2026-07-28` instead.
+
 ### Changed
 
 - **Breaking: the deprecated `initialize` handshake is now refused.** review-raven serves MCP protocol `2026-07-28` only, so a POST carrying an `initialize` call is answered with HTTP 400 and JSON-RPC `-32022` (`unsupported protocol version`), whose `data` advertises `supported: ["2026-07-28"]` and echoes the version the client asked for. A batched body is rejected as a whole, so that response carries a null `id` — no single request in the batch owns it. Previously go-sdk answered the handshake and negotiated down to the client's legacy revision — a Codex 0.149.1 A/B run (`mcp_2026_07_28` disabled process-locally) showed review-raven staying `ready` on `2025-06-18` where thread-owl already rejected it, leaving review-raven the last server in the review stack that a pre-SEP-2575 client could still reach. go-sdk exposes no server-side switch for this, so the handshake is gated in front of the SDK handler; the gate matches the modern-only rejection the TS SDK serves thread-owl via `legacy: "reject"`. Clients must discover the server through `server/discover`. Part of the [thread-owl#165](https://github.com/scottlz0310/thread-owl/issues/165) cross-repo MCP `2026-07-28` migration. ([Issue #117](https://github.com/scottlz0310/review-raven/issues/117))
@@ -174,6 +178,7 @@ If you were running with `AUTH_MODE=standalone` or `AUTH_MODE=gateway`:
 - This standalone repository preserves release continuity from the original `review-raven` service work in Mcp-Docker; git history was not migrated.
 - See `docs/` for related design context and migration history.
 
-[Unreleased]: https://github.com/scottlz0310/review-raven/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/review-raven/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/scottlz0310/review-raven/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/scottlz0310/review-raven/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/scottlz0310/review-raven/releases/tag/v0.1.0

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -84,7 +84,7 @@ func BuildStreamableHandlerWithOptions(db *store.DB, threshold time.Duration, op
 	// fully initialized, so watchManager is always non-nil.
 	var watchManager *watch.Manager
 	srv := mcp.NewServer(
-		&mcp.Implementation{Name: "review-raven", Version: "0.2.0"},
+		&mcp.Implementation{Name: "review-raven", Version: "0.3.0"},
 		&mcp.ServerOptions{
 			SchemaCache: schemaCache,
 			SubscribeHandler: func(ctx context.Context, req *mcp.SubscribeRequest) error {


### PR DESCRIPTION
## 概要

v0.2.0 以降に溜まった `[Unreleased]` を **v0.3.0** として切り出すリリース準備 PR です。

未リリース分は #118（Issue #117）の 1 件のみですが、内容が **破壊的変更**（非推奨の `initialize` handshake を拒否し、`server/discover` 経由の discovery を必須化）のため、パッチではなく minor bump としています。v0.2.0 も同様に破壊的変更を含む minor bump で切っており、その運用に揃えました。

## 変更内容

- `CHANGELOG.md` / `CHANGELOG.ja.md`
  - `[Unreleased]` → `[0.3.0] - 2026-08-26` として切り出し
  - 破壊的リリースであることを示す callout を 0.2.0 と同じ形式で追加
  - compare リンク（`[Unreleased]` / `[0.3.0]`）を更新
- `internal/tools/server.go`
  - client へ報告する `mcp.Implementation` の `Version` を `0.2.0` → `0.3.0`

## リリース後の影響

`initialize` handshake で接続する pre-SEP-2575 client は HTTP 400 / JSON-RPC `-32022` で拒否されます。client は MCP protocol `2026-07-28` の `server/discover` で discovery する必要があります。[thread-owl#165](https://github.com/scottlz0310/thread-owl/issues/165) の repo 横断移行の一環です。

## 確認

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` （全パッケージ ok）
- [x] `gofmt` — 差分は Windows checkout の CRLF 起因のみで、本 PR の変更ファイルには無し

🤖 Generated with [Claude Code](https://claude.com/claude-code)
