### PR TITLE
feat: add metadata-only review thread projection

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,6 +9,10 @@
 
 ## [Unreleased]
 
+### 追加
+
+- `get_review_threads` に `include_bodies: false` のメタデータのみの射影を追加しました。GraphQL query レベルでレビュースレッド本文を選択せず、コメント ID・投稿者メタデータ・URL・スレッドの解決状態・ページネーション完了情報を返します。([Issue #124](https://github.com/scottlz0310/review-raven/issues/124))
+
 ### 修正
 
 - stale-guard バグ報告の旧ディレクトリを参照するリンク5件を、現行の `internal/` 配下へ修正しました。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a metadata-only projection to `get_review_threads` via `include_bodies: false`. The projection omits review comment bodies at the GraphQL query level while returning comment IDs, author metadata, URLs, thread resolution state, and pagination completion information. ([Issue #124](https://github.com/scottlz0310/review-raven/issues/124))
+
 ### Removed
 
 - Removed both language versions of `review-raven-thread-owl-cycle` from this repository, consolidating skill source and installation in Mcp-Docker. Retired the English skill and both language versions of the unused Copilot-only `pr-review-cycle`, and updated the guides to reference Mcp-Docker's canonical source and installation instructions. ([Issue #122](https://github.com/scottlz0310/review-raven/issues/122))

--- a/README.ja.md
+++ b/README.ja.md
@@ -37,6 +37,8 @@ PR レビューを受けて直す側の MCP（Model Context Protocol）サーバ
 | `wait_for_copilot_review` | legacy blocking wait（fallback） |
 | `diagnose_github_token` | 現在のトークンの login と OAuth スコープ(`X-OAuth-Scopes` レスポンスヘッダー由来)を返す。`PERMISSION_DENIED` の原因切り分け用 |
 
+`get_review_threads` は任意の `include_bodies` input を受け付けます。後方互換性のため省略時は `true` です。`false` を指定すると、GitHub からレビュースレッド本文を選択しないメタデータのみの射影を返します。レスポンスにはコメント ID、投稿者メタデータ、URL、スレッドの解決状態、ページネーション完了情報が含まれます。
+
 セットアップと運用は [docs/usage.ja.md](docs/usage.ja.md) を参照。ツール単位の詳細は [docs/watch-tools.ja.md](docs/watch-tools.ja.md) と [skill の所在・配置案内](docs/skills/README.md) を参照。アーキテクチャおよび Thread Owl・mcp-resource-subscriber との責務境界は [docs/architecture.ja.md](docs/architecture.ja.md) を参照。
 
 ## クイックスタート（Docker + mcp-gateway）

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ An MCP (Model Context Protocol) server for the **reviewed side** of a PR review 
 | `wait_for_copilot_review` | Legacy blocking wait (fallback) |
 | `diagnose_github_token` | Report the current token's login and OAuth scopes (from the `X-OAuth-Scopes` response header) for diagnosing `PERMISSION_DENIED` failures |
 
+`get_review_threads` accepts the optional `include_bodies` input. It defaults to `true` for compatibility; set it to `false` to receive a metadata-only projection that does not select review comment bodies from GitHub. The response includes comment IDs, author metadata, URLs, thread resolution state, and pagination completion information.
+
 See [docs/usage.md](docs/usage.md) for setup and operation. Tool-level details are in [docs/watch-tools.md](docs/watch-tools.md); skill location and installation are described in the [skill guide (Japanese)](docs/skills/README.md). For the architecture and responsibility boundaries with Thread Owl and mcp-resource-subscriber, see [docs/architecture.md](docs/architecture.md).
 
 ## Quick Start (Docker + mcp-gateway)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -4,6 +4,8 @@
 
 ## 実装済み（未マージ）
 
+- [x] [#124](https://github.com/scottlz0310/review-raven/issues/124): `get_review_threads` に本文を選択しないメタデータ射影 API を追加し、投稿者ゲートの事前検査を MCP から利用できるようにした。
+
 - [x] #123 一周目レビュー対応: 英語版ドキュメントの日本語混入を修正し、stale-guard バグ報告の既存参照切れ5件を解消。
 
 - [x] [#122](https://github.com/scottlz0310/review-raven/issues/122): skill の収蔵・配置案内を Mcp-Docker へ統一。`review-raven-thread-owl-cycle` 日英版と未使用の `pr-review-cycle` 日英版を削除し、英語版を廃止。

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -507,13 +507,69 @@ type reviewThreadNode struct {
 	StartLine  *githubv4.Int
 	Comments   struct {
 		Nodes []struct {
-			Body      githubv4.String
-			CreatedAt githubv4.DateTime
-			Author    struct {
-				Login githubv4.String
+			DatabaseID int64
+			URL        githubv4.String
+			Body       githubv4.String
+			CreatedAt  githubv4.DateTime
+			Author     struct {
+				Login    githubv4.String
+				TypeName githubv4.String `graphql:"__typename"`
 			}
 		}
 	} `graphql:"comments(first: 10)"`
+}
+
+// reviewThreadMetadataComment は投稿者ゲートで使う本文なしコメント射影です。
+// 射影を分離することで、メタデータのみの取得時に GitHub から本文を選択しません。
+type reviewThreadMetadataComment struct {
+	DatabaseID int64
+	URL        githubv4.String
+	CreatedAt  githubv4.DateTime
+	Author     struct {
+		Login    githubv4.String
+		TypeName githubv4.String `graphql:"__typename"`
+	}
+}
+
+type reviewThreadMetadataComments struct {
+	Nodes    []reviewThreadMetadataComment
+	PageInfo struct {
+		HasNextPage githubv4.Boolean
+		EndCursor   githubv4.String
+	}
+}
+
+type reviewThreadMetadataNode struct {
+	ID         githubv4.ID
+	IsResolved githubv4.Boolean
+	IsOutdated githubv4.Boolean
+	Path       githubv4.String
+	Line       *githubv4.Int
+	StartLine  *githubv4.Int
+	Comments   reviewThreadMetadataComments `graphql:"comments(first: 50)"`
+}
+
+// reviewThreadsMetadataPageQuery は GraphQL で PR レビュースレッドの本文なしページを取得します。
+type reviewThreadsMetadataPageQuery struct {
+	Repository struct {
+		PullRequest struct {
+			ReviewThreads struct {
+				Nodes    []reviewThreadMetadataNode
+				PageInfo struct {
+					HasNextPage githubv4.Boolean
+					EndCursor   githubv4.String
+				}
+			} `graphql:"reviewThreads(first: 100, after: $cursor)"`
+		} `graphql:"pullRequest(number: $pr)"`
+	} `graphql:"repository(owner: $owner, name: $repo)"`
+}
+
+type reviewThreadMetadataCommentsPageQuery struct {
+	Node struct {
+		PullRequestReviewThread struct {
+			Comments reviewThreadMetadataComments `graphql:"comments(first: 50, after: $cursor)"`
+		} `graphql:"... on PullRequestReviewThread"`
+	} `graphql:"node(id: $id)"`
 }
 
 // threadNodeQuery fetches a single thread's resolved status by global node ID.
@@ -567,9 +623,12 @@ type ResolveReviewThreadInput struct {
 
 // ThreadComment is a single comment within a review thread.
 type ThreadComment struct {
-	Author    string
-	Body      string
-	CreatedAt string
+	CommentID  string
+	Author     string
+	AuthorType string
+	URL        string
+	Body       string
+	CreatedAt  string
 }
 
 // ReviewThread is the parsed representation of a PR review thread.
@@ -583,6 +642,19 @@ type ReviewThread struct {
 	Comments   []ThreadComment
 }
 
+// ReviewThreadsOptions は GetReviewThreadsWithOptions が選択するフィールドを制御します。
+type ReviewThreadsOptions struct {
+	// IncludeBodies はレビュコメント本文を選択します。信頼できる投稿者の検証前に使う
+	// メタデータのみの射影では false に設定します。
+	IncludeBodies bool
+}
+
+// ReviewThreadsResult は GitHub から返された全ページと、消費した reviewThreads ページ数を含みます。
+type ReviewThreadsResult struct {
+	Threads   []ReviewThread
+	PageCount int
+}
+
 // ReplyResult holds the result of a reply-to-thread operation.
 type ReplyResult struct {
 	CommentID string
@@ -593,27 +665,58 @@ type ReplyResult struct {
 
 // GetReviewThreads fetches all review threads for a PR using GraphQL (paginated).
 func (c *Client) GetReviewThreads(ctx context.Context, owner, repo string, pr int) ([]ReviewThread, error) {
-	if pr <= 0 || pr > math.MaxInt32 {
-		return nil, fmt.Errorf("pr number out of valid range: %d", pr)
+	result, err := c.GetReviewThreadsWithOptions(ctx, owner, repo, pr, ReviewThreadsOptions{IncludeBodies: true})
+	if err != nil {
+		return nil, err
 	}
+	return result.Threads, nil
+}
+
+// GetReviewThreadsWithOptions はページネーション付き GraphQL 射影で PR の全レビュースレッドを取得します。
+// メタデータのみのモードではコメント本文を選択しません。
+func (c *Client) GetReviewThreadsWithOptions(
+	ctx context.Context,
+	owner, repo string,
+	pr int,
+	options ReviewThreadsOptions,
+) (ReviewThreadsResult, error) {
+	if pr <= 0 || pr > math.MaxInt32 {
+		return ReviewThreadsResult{}, fmt.Errorf("pr number out of valid range: %d", pr)
+	}
+	if !options.IncludeBodies {
+		return c.getReviewThreadMetadata(ctx, owner, repo, pr)
+	}
+	return c.getReviewThreadsWithBodies(ctx, owner, repo, pr)
+}
+
+func reviewThreadsVariables(owner, repo string, pr int) map[string]interface{} {
 	vars := map[string]interface{}{
 		"owner":  githubv4.String(owner),
 		"repo":   githubv4.String(repo),
 		"pr":     githubv4.Int(int32(pr)), //nolint:gosec // range checked above
 		"cursor": (*githubv4.String)(nil),
 	}
+	return vars
+}
 
+func (c *Client) getReviewThreadsWithBodies(ctx context.Context, owner, repo string, pr int) (ReviewThreadsResult, error) {
+	vars := reviewThreadsVariables(owner, repo, pr)
 	var allNodes []reviewThreadNode
+	pageCount := 0
 	for {
 		var q reviewThreadsPageQuery
 		if err := c.v4.Query(ctx, &q, vars); err != nil {
-			return nil, fmt.Errorf("graphql query failed: %w", err)
+			return ReviewThreadsResult{}, fmt.Errorf("graphql query failed: %w", err)
 		}
+		pageCount++
 		allNodes = append(allNodes, q.Repository.PullRequest.ReviewThreads.Nodes...)
 		if !bool(q.Repository.PullRequest.ReviewThreads.PageInfo.HasNextPage) {
 			break
 		}
 		cursor := q.Repository.PullRequest.ReviewThreads.PageInfo.EndCursor
+		if cursor == "" {
+			return ReviewThreadsResult{}, fmt.Errorf("graphql query returned hasNextPage=true with empty endCursor")
+		}
 		vars["cursor"] = &cursor
 	}
 
@@ -635,14 +738,114 @@ func (c *Client) GetReviewThreads(ctx context.Context, owner, repo string, pr in
 		}
 		for _, c := range n.Comments.Nodes {
 			t.Comments = append(t.Comments, ThreadComment{
-				Author:    string(c.Author.Login),
-				Body:      string(c.Body),
-				CreatedAt: c.CreatedAt.Format(time.RFC3339),
+				CommentID:  formatCommentID(c.DatabaseID),
+				Author:     string(c.Author.Login),
+				AuthorType: string(c.Author.TypeName),
+				URL:        string(c.URL),
+				Body:       string(c.Body),
+				CreatedAt:  c.CreatedAt.Format(time.RFC3339),
 			})
 		}
 		threads = append(threads, t)
 	}
-	return threads, nil
+	return ReviewThreadsResult{Threads: threads, PageCount: pageCount}, nil
+}
+
+func (c *Client) getReviewThreadMetadata(ctx context.Context, owner, repo string, pr int) (ReviewThreadsResult, error) {
+	vars := reviewThreadsVariables(owner, repo, pr)
+	var allNodes []reviewThreadMetadataNode
+	pageCount := 0
+	for {
+		var q reviewThreadsMetadataPageQuery
+		if err := c.v4.Query(ctx, &q, vars); err != nil {
+			return ReviewThreadsResult{}, fmt.Errorf("graphql metadata query failed: %w", err)
+		}
+		pageCount++
+		allNodes = append(allNodes, q.Repository.PullRequest.ReviewThreads.Nodes...)
+		if !bool(q.Repository.PullRequest.ReviewThreads.PageInfo.HasNextPage) {
+			break
+		}
+		cursor := q.Repository.PullRequest.ReviewThreads.PageInfo.EndCursor
+		if cursor == "" {
+			return ReviewThreadsResult{}, fmt.Errorf("graphql metadata query returned hasNextPage=true with empty endCursor")
+		}
+		vars["cursor"] = &cursor
+	}
+
+	threads := make([]ReviewThread, 0, len(allNodes))
+	for _, n := range allNodes {
+		t := ReviewThread{
+			ID:         fmt.Sprintf("%v", n.ID),
+			IsResolved: bool(n.IsResolved),
+			IsOutdated: bool(n.IsOutdated),
+			Path:       string(n.Path),
+		}
+		if n.Line != nil {
+			v := int32(*n.Line)
+			t.Line = &v
+		}
+		if n.StartLine != nil {
+			v := int32(*n.StartLine)
+			t.StartLine = &v
+		}
+		if err := c.appendReviewThreadMetadataComments(ctx, &t, n.ID, n.Comments); err != nil {
+			return ReviewThreadsResult{}, err
+		}
+		threads = append(threads, t)
+	}
+	return ReviewThreadsResult{Threads: threads, PageCount: pageCount}, nil
+}
+
+func (c *Client) appendReviewThreadMetadataComments(
+	ctx context.Context,
+	thread *ReviewThread,
+	threadID githubv4.ID,
+	comments reviewThreadMetadataComments,
+) error {
+	appendComments := func(page reviewThreadMetadataComments) {
+		for _, comment := range page.Nodes {
+			thread.Comments = append(thread.Comments, ThreadComment{
+				CommentID:  formatCommentID(comment.DatabaseID),
+				Author:     string(comment.Author.Login),
+				AuthorType: string(comment.Author.TypeName),
+				URL:        string(comment.URL),
+				CreatedAt:  comment.CreatedAt.Format(time.RFC3339),
+			})
+		}
+	}
+
+	appendComments(comments)
+	if !bool(comments.PageInfo.HasNextPage) {
+		return nil
+	}
+
+	vars := map[string]interface{}{
+		"id":     threadID,
+		"cursor": (*githubv4.String)(nil),
+	}
+	for {
+		var q reviewThreadMetadataCommentsPageQuery
+		if err := c.v4.Query(ctx, &q, vars); err != nil {
+			return fmt.Errorf("graphql metadata comments query failed: %w", err)
+		}
+		page := q.Node.PullRequestReviewThread.Comments
+		appendComments(page)
+		if !bool(page.PageInfo.HasNextPage) {
+			return nil
+		}
+		cursor := page.PageInfo.EndCursor
+		if cursor == "" {
+			return fmt.Errorf("graphql metadata comments query returned hasNextPage=true with empty endCursor")
+		}
+		vars["cursor"] = &cursor
+	}
+}
+
+func formatCommentID(databaseID int64) string {
+	if databaseID <= 0 {
+		return ""
+	}
+	return strconv.FormatInt(databaseID, 10)
 }
 
 // IsThreadResolved checks whether a review thread is already resolved.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -819,9 +819,13 @@ func (c *Client) appendReviewThreadMetadataComments(
 		return nil
 	}
 
+	initialCursor := comments.PageInfo.EndCursor
+	if initialCursor == "" {
+		return fmt.Errorf("graphql metadata comments query returned hasNextPage=true with empty endCursor")
+	}
 	vars := map[string]interface{}{
 		"id":     threadID,
-		"cursor": (*githubv4.String)(nil),
+		"cursor": &initialCursor,
 	}
 	for {
 		var q reviewThreadMetadataCommentsPageQuery

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -516,7 +516,7 @@ func TestGetCIStatus(t *testing.T) {
 		{
 			name: "same app, same name: latest (higher ID) wins; stale in_progress ignored",
 			checksJSON: makeChecksJSON(
-				makeRun(1, 0, "ci/build", "in_progress", ""),   // older: stale
+				makeRun(1, 0, "ci/build", "in_progress", ""),      // older: stale
 				makeRun(2, 0, "ci/build", "completed", "success"), // latest: success
 			),
 			want: CIStatus{OK: true},
@@ -927,6 +927,289 @@ func TestIsCopilotLoginCoversAllKnownIdentities(t *testing.T) {
 		got := IsCopilotLogin(tc.login)
 		if got != tc.want {
 			t.Errorf("IsCopilotLogin(%q) = %v, want %v", tc.login, got, tc.want)
+		}
+	}
+}
+
+func TestGetReviewThreadsWithOptionsProjectionAndPagination(t *testing.T) {
+	tests := []struct {
+		name             string
+		options          ReviewThreadsOptions
+		wantBody         string
+		wantBodySelected bool
+	}{
+		{
+			name:             "metadata-only",
+			options:          ReviewThreadsOptions{IncludeBodies: false},
+			wantBodySelected: false,
+		},
+		{
+			name:             "full",
+			options:          ReviewThreadsOptions{IncludeBodies: true},
+			wantBody:         "secret review body",
+			wantBodySelected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var queries []string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var request struct {
+					Query     string                     `json:"query"`
+					Variables map[string]json.RawMessage `json:"variables"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					t.Fatalf("decode GraphQL request: %v", err)
+				}
+				queries = append(queries, request.Query)
+
+				page := 1
+				if cursor := request.Variables["cursor"]; len(cursor) > 0 && string(cursor) != "null" {
+					page = 2
+				}
+				login := "thread-owl[bot]"
+				if page == 2 {
+					login = "scottlz0310-user"
+				}
+				comment := map[string]any{
+					"databaseId": 1000 + page,
+					"url":        fmt.Sprintf("https://github.com/example/review/%d", page),
+					"author": map[string]any{
+						"login":      login,
+						"__typename": "Bot",
+					},
+					"createdAt": "2026-09-10T00:00:00Z",
+				}
+				if tc.wantBodySelected {
+					comment["body"] = tc.wantBody
+				}
+				node := map[string]any{
+					"id":         fmt.Sprintf("PRRT_%d", page),
+					"isResolved": page == 2,
+					"isOutdated": false,
+					"path":       "main.go",
+					"line":       10 + page,
+					"startLine":  10 + page,
+					"comments": map[string]any{
+						"nodes": []any{comment},
+					},
+				}
+				response := map[string]any{
+					"data": map[string]any{
+						"repository": map[string]any{
+							"pullRequest": map[string]any{
+								"reviewThreads": map[string]any{
+									"nodes": []any{node},
+									"pageInfo": map[string]any{
+										"hasNextPage": page == 1,
+										"endCursor":   fmt.Sprintf("cursor-%d", page),
+									},
+								},
+							},
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			t.Cleanup(srv.Close)
+
+			client, err := NewWithHTTPClientAndURLFull(srv.Client(), srv.URL, 30*time.Second)
+			if err != nil {
+				t.Fatalf("NewWithHTTPClientAndURLFull() error = %v", err)
+			}
+			result, err := client.GetReviewThreadsWithOptions(context.Background(), "example", "repo", 1, tc.options)
+			if err != nil {
+				t.Fatalf("GetReviewThreadsWithOptions() error = %v", err)
+			}
+			if result.PageCount != 2 {
+				t.Fatalf("PageCount = %d, want 2", result.PageCount)
+			}
+			if len(result.Threads) != 2 {
+				t.Fatalf("len(Threads) = %d, want 2", len(result.Threads))
+			}
+			comment := result.Threads[0].Comments[0]
+			if comment.CommentID != "1001" {
+				t.Errorf("CommentID = %q, want 1001", comment.CommentID)
+			}
+			if comment.Author != "thread-owl[bot]" {
+				t.Errorf("Author = %q, want thread-owl[bot]", comment.Author)
+			}
+			if comment.AuthorType != "Bot" {
+				t.Errorf("AuthorType = %q, want Bot", comment.AuthorType)
+			}
+			if comment.URL == "" {
+				t.Error("URL is empty, want review comment URL")
+			}
+			if comment.Body != tc.wantBody {
+				t.Errorf("Body = %q, want %q", comment.Body, tc.wantBody)
+			}
+			for _, query := range queries {
+				selected := strings.Contains(query, "body")
+				if selected != tc.wantBodySelected {
+					t.Errorf("query body selection = %v, want %v; query = %s", selected, tc.wantBodySelected, query)
+				}
+			}
+		})
+	}
+}
+
+func TestGetReviewThreadsDefaultIncludesBodies(t *testing.T) {
+	var query string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode GraphQL request: %v", err)
+		}
+		query = request.Query
+		response := map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"pullRequest": map[string]any{
+						"reviewThreads": map[string]any{
+							"nodes": []any{map[string]any{
+								"id":         "PRRT_default",
+								"isResolved": false,
+								"isOutdated": false,
+								"comments": map[string]any{
+									"nodes": []any{map[string]any{
+										"databaseId": 7,
+										"url":        "https://github.com/example/review/7",
+										"body":       "full review body",
+										"createdAt":  "2026-09-10T00:00:00Z",
+										"author": map[string]any{
+											"login":      "thread-owl[bot]",
+											"__typename": "Bot",
+										},
+									}},
+								},
+							}},
+							"pageInfo": map[string]any{
+								"hasNextPage": false,
+								"endCursor":   "cursor-1",
+							},
+						},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewWithHTTPClientAndURLFull(srv.Client(), srv.URL, 30*time.Second)
+	if err != nil {
+		t.Fatalf("NewWithHTTPClientAndURLFull() error = %v", err)
+	}
+	threads, err := client.GetReviewThreads(context.Background(), "example", "repo", 1)
+	if err != nil {
+		t.Fatalf("GetReviewThreads() error = %v", err)
+	}
+	if len(threads) != 1 || len(threads[0].Comments) != 1 {
+		t.Fatalf("thread/comment counts = %d/%d, want 1/1", len(threads), len(threads[0].Comments))
+	}
+	if threads[0].Comments[0].Body != "full review body" {
+		t.Errorf("Body = %q, want full review body", threads[0].Comments[0].Body)
+	}
+	if !strings.Contains(query, "body") {
+		t.Errorf("default GraphQL query omitted body: %s", query)
+	}
+}
+
+func TestGetReviewThreadsMetadataPaginatesThreadComments(t *testing.T) {
+	var queries []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode GraphQL request: %v", err)
+		}
+		queries = append(queries, request.Query)
+		comment := func(id int) map[string]any {
+			return map[string]any{
+				"databaseId": id,
+				"url":        fmt.Sprintf("https://github.com/example/review/%d", id),
+				"createdAt":  "2026-09-10T00:00:00Z",
+				"author": map[string]any{
+					"login":      "thread-owl[bot]",
+					"__typename": "Bot",
+				},
+			}
+		}
+
+		var response map[string]any
+		if strings.Contains(request.Query, "reviewThreads") {
+			response = map[string]any{
+				"data": map[string]any{
+					"repository": map[string]any{
+						"pullRequest": map[string]any{
+							"reviewThreads": map[string]any{
+								"nodes": []any{map[string]any{
+									"id":         "PRRT_comments",
+									"isResolved": false,
+									"isOutdated": false,
+									"comments": map[string]any{
+										"nodes": []any{comment(1)},
+										"pageInfo": map[string]any{
+											"hasNextPage": true,
+											"endCursor":   "comment-cursor-1",
+										},
+									},
+								}},
+								"pageInfo": map[string]any{
+									"hasNextPage": false,
+									"endCursor":   "thread-cursor-1",
+								},
+							},
+						},
+					},
+				},
+			}
+		} else {
+			response = map[string]any{
+				"data": map[string]any{
+					"node": map[string]any{
+						"comments": map[string]any{
+							"nodes": []any{comment(2)},
+							"pageInfo": map[string]any{
+								"hasNextPage": false,
+								"endCursor":   "comment-cursor-2",
+							},
+						},
+					},
+				},
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewWithHTTPClientAndURLFull(srv.Client(), srv.URL, 30*time.Second)
+	if err != nil {
+		t.Fatalf("NewWithHTTPClientAndURLFull() error = %v", err)
+	}
+	result, err := client.GetReviewThreadsWithOptions(context.Background(), "example", "repo", 1, ReviewThreadsOptions{})
+	if err != nil {
+		t.Fatalf("GetReviewThreadsWithOptions() error = %v", err)
+	}
+	if result.PageCount != 1 || len(result.Threads) != 1 || len(result.Threads[0].Comments) != 2 {
+		t.Fatalf("result pages/threads/comments = %d/%d/%d, want 1/1/2", result.PageCount, len(result.Threads), len(result.Threads[0].Comments))
+	}
+	if result.Threads[0].Comments[1].CommentID != "2" {
+		t.Errorf("second CommentID = %q, want 2", result.Threads[0].Comments[1].CommentID)
+	}
+	if len(queries) != 2 {
+		t.Fatalf("GraphQL query count = %d, want 2", len(queries))
+	}
+	for _, query := range queries {
+		if strings.Contains(query, "body") {
+			t.Errorf("metadata-only query selected body: %s", query)
 		}
 	}
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1124,7 +1124,8 @@ func TestGetReviewThreadsMetadataPaginatesThreadComments(t *testing.T) {
 	var queries []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var request struct {
-			Query string `json:"query"`
+			Query     string                     `json:"query"`
+			Variables map[string]json.RawMessage `json:"variables"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			t.Fatalf("decode GraphQL request: %v", err)
@@ -1171,6 +1172,11 @@ func TestGetReviewThreadsMetadataPaginatesThreadComments(t *testing.T) {
 				},
 			}
 		} else {
+			var cursor string
+			if err := json.Unmarshal(request.Variables["cursor"], &cursor); err != nil || cursor != "comment-cursor-1" {
+				http.Error(w, "unexpected comment cursor", http.StatusBadRequest)
+				return
+			}
 			response = map[string]any{
 				"data": map[string]any{
 					"node": map[string]any{
@@ -1211,5 +1217,119 @@ func TestGetReviewThreadsMetadataPaginatesThreadComments(t *testing.T) {
 		if strings.Contains(query, "body") {
 			t.Errorf("metadata-only query selected body: %s", query)
 		}
+	}
+}
+
+func TestGetReviewThreadsMetadataRejectsEmptyCursor(t *testing.T) {
+	comment := map[string]any{
+		"databaseId": 1,
+		"url":        "https://github.com/example/review/1",
+		"createdAt":  "2026-09-10T00:00:00Z",
+		"author": map[string]any{
+			"login":      "thread-owl[bot]",
+			"__typename": "Bot",
+		},
+	}
+
+	tests := []struct {
+		name          string
+		threadPage    map[string]any
+		commentPage   map[string]any
+		wantErrorPart string
+	}{
+		{
+			name: "thread page",
+			threadPage: map[string]any{
+				"hasNextPage": true,
+				"endCursor":   "",
+			},
+			wantErrorPart: "graphql metadata query returned hasNextPage=true with empty endCursor",
+		},
+		{
+			name: "initial comment page",
+			threadPage: map[string]any{
+				"hasNextPage": false,
+				"endCursor":   "thread-cursor-1",
+			},
+			commentPage: map[string]any{
+				"hasNextPage": true,
+				"endCursor":   "",
+			},
+			wantErrorPart: "graphql metadata comments query returned hasNextPage=true with empty endCursor",
+		},
+		{
+			name: "nested comment page",
+			threadPage: map[string]any{
+				"hasNextPage": false,
+				"endCursor":   "thread-cursor-1",
+			},
+			commentPage: map[string]any{
+				"hasNextPage": true,
+				"endCursor":   "comment-cursor-1",
+			},
+			wantErrorPart: "graphql metadata comments query returned hasNextPage=true with empty endCursor",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var request struct {
+					Query string `json:"query"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					t.Fatalf("decode GraphQL request: %v", err)
+				}
+
+				response := map[string]any{
+					"data": map[string]any{
+						"repository": map[string]any{
+							"pullRequest": map[string]any{
+								"reviewThreads": map[string]any{
+									"nodes":    []any{},
+									"pageInfo": tc.threadPage,
+								},
+							},
+						},
+					},
+				}
+				if tc.commentPage != nil {
+					if strings.Contains(request.Query, "reviewThreads") {
+						response["data"].(map[string]any)["repository"].(map[string]any)["pullRequest"].(map[string]any)["reviewThreads"].(map[string]any)["nodes"] = []any{map[string]any{
+							"id":         "PRRT_cursor",
+							"isResolved": false,
+							"isOutdated": false,
+							"comments": map[string]any{
+								"nodes":    []any{comment},
+								"pageInfo": tc.commentPage,
+							},
+						}}
+					} else {
+						response = map[string]any{
+							"data": map[string]any{
+								"node": map[string]any{
+									"comments": map[string]any{
+										"nodes":    []any{},
+										"pageInfo": map[string]any{"hasNextPage": true, "endCursor": ""},
+									},
+								},
+							},
+						}
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			t.Cleanup(srv.Close)
+
+			client, err := NewWithHTTPClientAndURLFull(srv.Client(), srv.URL, 30*time.Second)
+			if err != nil {
+				t.Fatalf("NewWithHTTPClientAndURLFull() error = %v", err)
+			}
+			_, err = client.GetReviewThreadsWithOptions(context.Background(), "example", "repo", 1, ReviewThreadsOptions{IncludeBodies: false})
+			if err == nil || !strings.Contains(err.Error(), tc.wantErrorPart) {
+				t.Fatalf("GetReviewThreadsWithOptions() error = %v, want %q", err, tc.wantErrorPart)
+			}
+		})
 	}
 }

--- a/internal/tools/threads.go
+++ b/internal/tools/threads.go
@@ -6,22 +6,28 @@ import (
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	ghclient "github.com/scottlz0310/review-raven/internal/github"
 )
 
 // ─── Tool 4: get_review_threads ───────────────────────────────────────────────
 
 // GetReviewThreadsInput is the input schema for get_review_threads.
 type GetReviewThreadsInput struct {
-	Owner string `json:"owner"`
-	Repo  string `json:"repo"`
-	PR    int    `json:"pr"`
+	Owner         string `json:"owner"`
+	Repo          string `json:"repo"`
+	PR            int    `json:"pr"`
+	IncludeBodies *bool  `json:"include_bodies,omitempty"`
 }
 
 // ThreadCommentOutput is a single comment within a thread result.
 type ThreadCommentOutput struct {
-	Author    string `json:"author"`
-	Body      string `json:"body"`
-	CreatedAt string `json:"createdAt"`
+	CommentID  string  `json:"commentId"`
+	Author     string  `json:"author"`
+	AuthorType string  `json:"authorType"`
+	URL        string  `json:"url"`
+	Body       *string `json:"body,omitempty"`
+	CreatedAt  string  `json:"createdAt"`
 }
 
 // ThreadResult is the result for a single review thread.
@@ -39,15 +45,23 @@ type ThreadSummary struct {
 	Unresolved int `json:"unresolved"`
 }
 
+// ThreadPaginationOutput はサーバーが消費したページ数を示します。クライアントは返却前に
+// 全ページを巡回するため、成功レスポンスは常に complete です。
+type ThreadPaginationOutput struct {
+	PageCount int  `json:"pageCount"`
+	Complete  bool `json:"complete"`
+}
+
 // GetReviewThreadsOutput is the output schema for get_review_threads.
 type GetReviewThreadsOutput struct {
-	Threads []ThreadResult `json:"threads"`
-	Summary ThreadSummary  `json:"summary"`
+	Threads    []ThreadResult         `json:"threads"`
+	Summary    ThreadSummary          `json:"summary"`
+	Pagination ThreadPaginationOutput `json:"pagination"`
 }
 
 var getReviewThreadsTool = &mcp.Tool{
 	Name:        "get_review_threads",
-	Description: "PR のレビュースレッド一覧（Raw コメントデータ）を返す。各スレッドに PRRT_xxx 形式の ID を含む。分類（blocking/non-blocking/suggestion）は呼び出し元 LLM がルールファイルに基づいて判断する。",
+	Description: "PR のレビュースレッド一覧（Raw コメントデータ）を返す。各スレッドに PRRT_xxx 形式の ID を含む。include_bodies=false を指定すると、コメント本文を GitHub から選択しないメタデータのみの射影を返す（省略時は true）。分類（blocking/non-blocking/suggestion）は呼び出し元 LLM がルールファイルに基づいて判断する。",
 }
 
 func getReviewThreadsHandler(
@@ -65,7 +79,13 @@ func getReviewThreadsHandler(
 			return nil, GetReviewThreadsOutput{}, err
 		}
 
-		rawThreads, err := gh.GetReviewThreads(ctx, in.Owner, in.Repo, in.PR)
+		includeBodies := true
+		if in.IncludeBodies != nil {
+			includeBodies = *in.IncludeBodies
+		}
+		threadResult, err := gh.GetReviewThreadsWithOptions(ctx, in.Owner, in.Repo, in.PR, ghclient.ReviewThreadsOptions{
+			IncludeBodies: includeBodies,
+		})
 		if err != nil {
 			if result, ok := tryAuthResult(err); ok {
 				return result, GetReviewThreadsOutput{}, nil
@@ -73,19 +93,26 @@ func getReviewThreadsHandler(
 			return nil, GetReviewThreadsOutput{}, err
 		}
 
-		summary := ThreadSummary{Total: len(rawThreads)}
-		results := make([]ThreadResult, 0, len(rawThreads))
-		for _, t := range rawThreads {
+		summary := ThreadSummary{Total: len(threadResult.Threads)}
+		results := make([]ThreadResult, 0, len(threadResult.Threads))
+		for _, t := range threadResult.Threads {
 			if !t.IsResolved {
 				summary.Unresolved++
 			}
 			comments := make([]ThreadCommentOutput, 0, len(t.Comments))
 			for _, c := range t.Comments {
-				comments = append(comments, ThreadCommentOutput{
-					Author:    c.Author,
-					Body:      c.Body,
-					CreatedAt: c.CreatedAt,
-				})
+				comment := ThreadCommentOutput{
+					CommentID:  c.CommentID,
+					Author:     c.Author,
+					AuthorType: c.AuthorType,
+					URL:        c.URL,
+					CreatedAt:  c.CreatedAt,
+				}
+				if includeBodies {
+					body := c.Body
+					comment.Body = &body
+				}
+				comments = append(comments, comment)
 			}
 			results = append(results, ThreadResult{
 				ID:         t.ID,
@@ -96,7 +123,11 @@ func getReviewThreadsHandler(
 			})
 		}
 
-		return nil, GetReviewThreadsOutput{Threads: results, Summary: summary}, nil
+		return nil, GetReviewThreadsOutput{
+			Threads:    results,
+			Summary:    summary,
+			Pagination: ThreadPaginationOutput{PageCount: threadResult.PageCount, Complete: true},
+		}, nil
 	}
 }
 

--- a/internal/tools/threads_test.go
+++ b/internal/tools/threads_test.go
@@ -1,0 +1,167 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	ghclient "github.com/scottlz0310/review-raven/internal/github"
+)
+
+func TestGetReviewThreadsHandlerMetadataOnlyOmitsBody(t *testing.T) {
+	var query string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode GraphQL request: %v", err)
+		}
+		query = request.Query
+		response := map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"pullRequest": map[string]any{
+						"reviewThreads": map[string]any{
+							"nodes": []any{map[string]any{
+								"id":         "PRRT_metadata",
+								"isResolved": false,
+								"isOutdated": false,
+								"path":       "main.go",
+								"line":       42,
+								"startLine":  42,
+								"comments": map[string]any{
+									"nodes": []any{map[string]any{
+										"databaseId": 42,
+										"url":        "https://github.com/example/review/42",
+										"author": map[string]any{
+											"login":      "thread-owl[bot]",
+											"__typename": "Bot",
+										},
+										"createdAt": "2026-09-10T00:00:00Z",
+									}},
+								},
+							}},
+							"pageInfo": map[string]any{
+								"hasNextPage": false,
+								"endCursor":   "cursor-1",
+							},
+						},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := ghclient.NewWithHTTPClientAndURLFull(srv.Client(), srv.URL, 30*time.Second)
+	if err != nil {
+		t.Fatalf("NewWithHTTPClientAndURLFull() error = %v", err)
+	}
+	handler := getReviewThreadsHandler(func(_ context.Context, _ *mcp.CallToolRequest) (*ghclient.Client, error) {
+		return client, nil
+	})
+	includeBodies := false
+	result, output, err := handler(context.Background(), nil, GetReviewThreadsInput{
+		Owner:         "example",
+		Repo:          "repo",
+		PR:            1,
+		IncludeBodies: &includeBodies,
+	})
+	if err != nil {
+		t.Fatalf("handler returned unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("handler result = %v, want nil", result)
+	}
+	if len(output.Threads) != 1 || len(output.Threads[0].Comments) != 1 {
+		t.Fatalf("output thread/comment counts = %d/%d, want 1/1", len(output.Threads), len(output.Threads[0].Comments))
+	}
+	comment := output.Threads[0].Comments[0]
+	if comment.CommentID != "42" {
+		t.Errorf("CommentID = %q, want 42", comment.CommentID)
+	}
+	if comment.AuthorType != "Bot" {
+		t.Errorf("AuthorType = %q, want Bot", comment.AuthorType)
+	}
+	if comment.Body != nil {
+		t.Errorf("Body = %q, want nil", *comment.Body)
+	}
+	if output.Pagination.PageCount != 1 || !output.Pagination.Complete {
+		t.Errorf("Pagination = %+v, want pageCount=1 and complete=true", output.Pagination)
+	}
+	if strings.Contains(strings.ToLower(query), "body") {
+		t.Errorf("metadata-only GraphQL query selected body: %s", query)
+	}
+	encoded, err := json.Marshal(output)
+	if err != nil {
+		t.Fatalf("json.Marshal(output) error = %v", err)
+	}
+	if strings.Contains(string(encoded), `"body"`) {
+		t.Errorf("metadata-only output contains body: %s", encoded)
+	}
+}
+
+func TestGetReviewThreadsSchemaAdvertisesOptionalBodyProjection(t *testing.T) {
+	ctx := context.Background()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	RegisterGetReviewThreadsTool(server, func(_ context.Context, _ *mcp.CallToolRequest) (*ghclient.Client, error) {
+		return nil, context.Canceled
+	})
+	serverConnection, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect() error = %v", err)
+	}
+	t.Cleanup(func() { _ = serverConnection.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect() error = %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+	var tool *mcp.Tool
+	for _, candidate := range tools.Tools {
+		if candidate.Name == "get_review_threads" {
+			tool = candidate
+			break
+		}
+	}
+	if tool == nil {
+		t.Fatal("get_review_threads tool was not advertised")
+	}
+
+	inputSchemaJSON, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Fatalf("json.Marshal(input schema) error = %v", err)
+	}
+	var inputSchema struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+		Required   []string                   `json:"required"`
+	}
+	if err := json.Unmarshal(inputSchemaJSON, &inputSchema); err != nil {
+		t.Fatalf("json.Unmarshal(input schema) error = %v; schema=%s", err, inputSchemaJSON)
+	}
+	if _, ok := inputSchema.Properties["include_bodies"]; !ok {
+		t.Fatalf("input schema does not advertise include_bodies: %s", inputSchemaJSON)
+	}
+	for _, required := range inputSchema.Required {
+		if required == "include_bodies" {
+			t.Fatalf("include_bodies is required but should be optional: %s", inputSchemaJSON)
+		}
+	}
+}


### PR DESCRIPTION
## 概要

`get_review_threads` に本文なしのメタデータ射影を追加し、投稿者ゲートの事前検査を MCP 経由で実行できるようにしました。

## 変更内容

- `include_bodies` を追加。省略時は `true` で既存動作を維持し、`false` では GraphQL request に `body` を含めない。
- metadata-only mode で comment ID、投稿者 login / 種別、URL、作成日時、thread 状態を返す。
- review thread と thread 内 comment のページネーションを最後まで処理する。
- `pageCount` / `complete` を出力し、空の `endCursor` による無限巡回を fail fast する。
- クライアント、MCP handler、公開 schema、既存本文取得の後方互換性をテストで固定した。
- README、CHANGELOG、tasks を更新した。

## 検証

- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`
- `go test -race` は環境の `CGO_ENABLED=0` により実行不可

## 関連

Closes #124

Mcp-Docker 側の skill 切替追従 Issue: https://github.com/scottlz0310/Mcp-Docker/issues/278
