### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -9,6 +9,8 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-10
+
 ### 追加
 
 - `get_review_threads` に `include_bodies: false` のメタデータのみの射影を追加しました。GraphQL query レベルでレビュースレッド本文を選択せず、コメント ID・投稿者メタデータ・URL・スレッドの解決状態・ページネーション完了情報を返します。([Issue #124](https://github.com/scottlz0310/review-raven/issues/124))
@@ -190,7 +192,8 @@
 - この独立リポジトリでは、Mcp-Docker 時代の `review-raven` service 作業から release continuity を引き継ぐ。git 履歴は移行していない。
 - 関連する設計・移行経緯は `docs/` 配下を参照。
 
-[Unreleased]: https://github.com/scottlz0310/review-raven/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/review-raven/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/scottlz0310/review-raven/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/scottlz0310/review-raven/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/scottlz0310/review-raven/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/scottlz0310/review-raven/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-10
+
 ### Added
 
 - Added a metadata-only projection to `get_review_threads` via `include_bodies: false`. The projection omits review comment bodies at the GraphQL query level while returning comment IDs, author metadata, URLs, thread resolution state, and pagination completion information. ([Issue #124](https://github.com/scottlz0310/review-raven/issues/124))
@@ -190,7 +192,8 @@ If you were running with `AUTH_MODE=standalone` or `AUTH_MODE=gateway`:
 - This standalone repository preserves release continuity from the original `review-raven` service work in Mcp-Docker; git history was not migrated.
 - See `docs/` for related design context and migration history.
 
-[Unreleased]: https://github.com/scottlz0310/review-raven/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/review-raven/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/scottlz0310/review-raven/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/scottlz0310/review-raven/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/scottlz0310/review-raven/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/scottlz0310/review-raven/releases/tag/v0.1.0

--- a/internal/tools/server.go
+++ b/internal/tools/server.go
@@ -84,7 +84,7 @@ func BuildStreamableHandlerWithOptions(db *store.DB, threshold time.Duration, op
 	// fully initialized, so watchManager is always non-nil.
 	var watchManager *watch.Manager
 	srv := mcp.NewServer(
-		&mcp.Implementation{Name: "review-raven", Version: "0.3.0"},
+		&mcp.Implementation{Name: "review-raven", Version: "0.4.0"},
 		&mcp.ServerOptions{
 			SchemaCache: schemaCache,
 			SubscribeHandler: func(ctx context.Context, req *mcp.SubscribeRequest) error {


### PR DESCRIPTION
## 概要

v0.3.0 以降の Unreleased 変更を v0.4.0 として切り出すリリース準備 PR です。

今回の変更は後方互換な get_review_threads のメタデータ専用射影追加が中心のため、Semantic Versioning の minor bump とします。

## 変更内容

- CHANGELOG.md / CHANGELOG.ja.md
  - Unreleased の内容を v0.4.0（2026-09-10）として切り出し
  - [Unreleased] と [0.4.0] の比較リンクを更新
- internal/tools/server.go
  - MCP client に報告するバージョンを 0.3.0 から 0.4.0 に更新

## リリース後

- v0.4.0 のタグ push で Release Container Image workflow を起動します。
- コンテナイメージは linux/amd64 と linux/arm64 向けにビルドされます。
- GitHub Release の公開とタグ push はこの PR には含めません。

## 確認

- [x] go test -count=1 ./...
- [x] go vet ./...
- [x] go build ./...
- [x] git diff --check

関連: マージ済み PR #126